### PR TITLE
fix: print something understandable when using add_file_output locally

### DIFF
--- a/openhexa/sdk/pipelines/run.py
+++ b/openhexa/sdk/pipelines/run.py
@@ -29,7 +29,7 @@ class CurrentRun:
             }
             self._graphql_query(query, variables)
         else:
-            print(f"Sending output with path {path} and name: {name}")
+            print(f"Sending output with path {stripped_path}")
 
     def add_database_output(self, table_name: str):
         if self.connected:


### PR DESCRIPTION
The distinction between path and name is not useful for the developer right now