### PR TITLE
feat(dependencies): Install extra dependencies if provided in pipeline

### DIFF
--- a/docker/bootstrap.py
+++ b/docker/bootstrap.py
@@ -54,6 +54,10 @@ def main():
         # setup sample files, et co...
         os.environ["OPENHEXA_LEGACY"] = "false"
 
+    if os.path.exists("pipeline/requirements.txt"):
+        print("Installing requirements...")
+        os.system("pip install -r pipeline/requirements.txt")
+
     print("Running pipeline...")
     pipeline = import_pipeline(".")
     config = json.loads(sys.argv[1])

--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -189,13 +189,17 @@ def upload_pipeline(config, pipeline_directory_path: str):
 
     zipFile = io.BytesIO(b"")
 
+    if is_debug(config):
+        click.echo("Generating ZIP file:")
+
     with ZipFile(zipFile, "w") as zipObj:
         for path in directory.glob("**/*"):
             if not path.is_file():
                 continue
-            if not path.name.endswith(".py"):
+            if not path.name.endswith(".py") and not path.name == "requirements.txt":
                 continue
-
+            if is_debug(config):
+                click.echo(f"\t{path.name}")
             zipObj.write(path, path.relative_to(directory))
 
     zipFile.seek(0)


### PR DESCRIPTION
Pipelines folder can contain a `requirements.txt` file. This file is uploaded with the code and when present in the pod, will be installed using `pip install` in bootstrap.py.

This can help user install python-only libraries in case they need a special package for their use case.