### PR TITLE
Add a GH workflow to publish the openhexa-pipelines image

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,51 @@
+name: Publish Pipelines Image on DockerHub
+
+on: 
+  workflow_dispatch:
+    inputs:
+      tag:
+          description: 'Tag to use for the image (e.g. 1.0.0, ...)'
+          required: true
+
+jobs:
+  publish:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+  
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            blsq/openhexa-pipelines
+          tags: |
+            type=semver,pattern={{version}},value=${{ github.event.inputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ github.event.inputs.tag }}
+            type=semver,pattern={{major}},value=${{ github.event.inputs.tag }}
+            type=sha
+
+      - name: Build and push (on release)
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: .
+          file: ./docker/Dockerfile
+          cache-from: type=registry,ref=blsq/openhexa-pipelines:buildcache
+          cache-to: type=registry,ref=blsq/openhexa-pipelines:buildcache,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -1,4 +1,4 @@
-name: Publish on PyPI
+name: Publish SDK on PyPI
 
 on: 
   release:

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -62,11 +62,12 @@ def workspaces_add(slug, token):
         get_workspace(user_config, slug, token)
     except Exception as e:
         click.echo(
-            "Error while getting workspace. Check the slug of the workspace and the access token.",
+            f"Error while getting workspace '{slug}' on {user_config['openhexa']['url']}. Check the slug of the workspace and the access token.",
             err=True,
         )
         if is_debug(user_config):
             raise e
+        return click.Abort()
 
     user_config["workspaces"].update({slug: token})
     user_config["openhexa"].update({"current_workspace": slug})
@@ -83,9 +84,11 @@ def workspaces_activate(slug):
 
     user_config = open_config()
     if slug not in user_config["workspaces"]:
-        click.echo(f"Workspace {slug} does not exist. Available workspaces:")
+        click.echo(
+            f"Workspace {slug} does not exist on {user_config['openhexa']['url']}. Available workspaces:"
+        )
         click.echo(", ".join(user_config["workspaces"].keys()))
-        return
+        return click.Abort()
     click.echo(f"Activating workspace {slug}")
     user_config["openhexa"].update({"current_workspace": slug})
 


### PR DESCRIPTION
This workflow is triggered manually by the user. The tag is taken from the inputs of the workflow and is used to create tags as follows:

Input: 1.1.3
Tags: blsq/openhexa-pipelines:latest, blsq/openhexa-pipelines:1.1.3, blsq/openhexa-pipelines:1.1, blsq/openhexa-pipelines:1, blsq/openhexa-pipelines:<sha> 

This is required to not use the latest image in production without testing it in demo.


⚠️ This workflow needs the `DOCKERHUB_USERNAME` & `DOCKERHUB_PASSWORD` to be set in the settings of the repository