### PR TITLE
fix: Adapt type parameter typing to accept floats in @parameter

### DIFF
--- a/openhexa/sdk/pipelines/parameter.py
+++ b/openhexa/sdk/pipelines/parameter.py
@@ -292,7 +292,9 @@ class Parameter:
 def parameter(
     code: str,
     *,
-    type: typing.Union[typing.Type[str], typing.Type[int], typing.Type[bool]],
+    type: typing.Union[
+        typing.Type[str], typing.Type[int], typing.Type[bool], typing.Type[float]
+    ],
     name: typing.Optional[str] = None,
     choices: typing.Optional[typing.Sequence] = None,
     help: typing.Optional[str] = None,


### PR DESCRIPTION
This PR simply updates the type annotations so that floats are officially accepted in the @parameter decorator.