### PR TITLE
fix: Proper error messages for arguments and missing config file

### DIFF
--- a/openhexa/sdk/pipelines/pipeline.py
+++ b/openhexa/sdk/pipelines/pipeline.py
@@ -195,8 +195,8 @@ class Pipeline:
             if argv or (args.config_file is not None and args.config is not None):
                 raise ValueError(
                     f"Unrecognized arguments: {' '.join(argv)}. Running a pipeline requires a single "
-                    "argument: either an inline JSON config with the --values/-v argument, or a JSON "
-                    "config file with the --values-file/-f argument."
+                    "argument: either an inline JSON config with the --config/-c argument, or a JSON "
+                    "config file with the --config-file/-f argument."
                 )
             if args.config_file is not None:
                 with open(args.config_file, "r") as cf:

--- a/openhexa/sdk/pipelines/utils.py
+++ b/openhexa/sdk/pipelines/utils.py
@@ -23,8 +23,9 @@ def get_local_workspace_config(path: Path):
     # (We will have to find another approach for tests or running the pipeline using the CLI)
     local_workspace_config_path = path / Path("workspace.yaml")
     if not local_workspace_config_path.exists():
-        print("Does not exist")
-        return
+        raise ValueError(
+            "To work with pipelines locally, you need a workspace.yaml file in the same directory as your pipeline file"
+        )
 
     with open(
         local_workspace_config_path.resolve(), "r"


### PR DESCRIPTION
Two fixes:

- Fixed the error message when incorrect CLI arguments were provided
- Raised a proper exception when workspace.yaml file is missing