### PR TITLE
fix: use proper namespace package setup

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,5 +21,5 @@ jobs:
           bump-minor-pre-major: true
           bump-patch-for-minor-pre-major: true
           include-v-in-tag: false
-          extra-files: openhexa/__init__.py
+          extra-files: openhexa/sdk/__init__.py
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'

--- a/openhexa/__init__.py
+++ b/openhexa/__init__.py
@@ -1,1 +1,0 @@
-__version__ = "0.1.21"  # {x-release-please-version}

--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -8,7 +8,7 @@ from zipfile import ZipFile
 import click
 import requests
 
-from openhexa import __version__
+from openhexa.sdk import __version__
 from openhexa.sdk.pipelines import import_pipeline
 
 CONFIGFILE_PATH = os.path.expanduser("~") + "/.openhexa.ini"

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import click
 import stringcase
 
-from openhexa import __version__
 from openhexa.cli.api import (
     create_pipeline,
     ensure_is_pipeline_dir,
@@ -17,6 +16,7 @@ from openhexa.cli.api import (
     save_config,
     upload_pipeline,
 )
+from openhexa.sdk import __version__
 from openhexa.sdk.pipelines import get_local_workspace_config, import_pipeline
 
 

--- a/openhexa/sdk/__init__.py
+++ b/openhexa/sdk/__init__.py
@@ -1,4 +1,6 @@
 from .pipelines import current_run, parameter, pipeline
 from .workspaces import workspace
 
+__version__ = "0.1.21"  # {x-release-please-version}
+
 __all__ = ["workspace", "pipeline", "parameter", "current_run"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = openhexa.sdk
-version = attr: openhexa.__version__
+version = attr: openhexa.sdk.__version__
 author = Bluesquare
 author_email = dev@bluesquarehub.com
 url = https://github.com/BLSQ/openhexa-sdk-python
@@ -17,7 +17,7 @@ classifiers =
 
 [options]
 python_requires = >=3.9
-packages = find:
+packages = find_namespace:
 zip_safe = True
 include_package_data = True
 install_requires =
@@ -26,6 +26,11 @@ install_requires =
     requests
     stringcase
     PyYAML
+
+[options.packages.find]
+where = .
+include = openhexa*
+namespaces = true
 
 [options.extras_require]
 dev = pytest;pytest-cov;pre-commit;build

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-# This file is still needed for editable installs
-
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
The goal of this PR is to make the packaging setup compliant with namespace packages guidelines (see https://packaging.python.org/en/latest/guides/packaging-namespace-packages/ and https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-namespace-packages).

Accordingly :

- [x] `__init__.py` removed from `openhexa` namespace directory
- [x] `__version__` attribute (used by release please) is moved to `openhexa.sdk`
- [x] `setup.cfg` adapted according to namespace packages guidelines