### PR TITLE
Simplify messages displayed in CLI for new pipelines

### DIFF
--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -268,7 +268,7 @@ def pipelines_push(path: str):
 
         if get_pipeline(user_config, pipeline.code) is None:
             click.echo(
-                f"Pipeline {click.style(pipeline.code, bold=True)} found in {path} does not exist in workspace {click.style(workspace, bold=True)}"
+                f"Pipeline {click.style(pipeline.code, bold=True)} does not exist in workspace {click.style(workspace, bold=True)}"
             )
             click.confirm(
                 f"Create pipeline {click.style(pipeline.code, bold=True)} in workspace {click.style(workspace, bold=True)}?",


### PR DESCRIPTION
Currently, this message often appears as "Pipeline found in . does not exist", which is confusing