### PR TITLE
fix(Pipelines): prevent upload of workspace folder content

### DIFF
--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -208,7 +208,9 @@ def upload_pipeline(config, pipeline_directory_path: str):
     files = []
     venv_path = None
     with ZipFile(zipFile, "w") as zipObj:
-        for path in directory.glob("**/*"):
+        # we need to exclude workspace folder and all its content
+        dirs = [path for path in directory.glob("**/*") if not (path.match("workspace/*") or path.name == "workspace")]
+        for path in dirs:
             if path.name == "python":
                 # We are in a virtual environment
                 venv_path = path.parent.parent  # ./<venv>/bin/python -> ./<venv>

--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -10,7 +10,7 @@ from zipfile import ZipFile
 import click
 import requests
 
-from openhexa.sdk.pipelines import import_pipeline
+from openhexa.sdk.pipelines import import_pipeline, get_local_workspace_config
 
 CONFIGFILE_PATH = os.path.expanduser("~") + "/.openhexa.ini"
 
@@ -207,10 +207,16 @@ def upload_pipeline(config, pipeline_directory_path: str):
         click.echo("Generating ZIP file:")
     files = []
     venv_path = None
+    env_vars = get_local_workspace_config(Path(pipeline_directory_path))
+    # default value for files path in workspace.yaml
+    excluded_dirs = ["workspace"]
+    if env_vars.get("WORKSPACE_FILES_PATH"):
+        excluded_dirs.append(Path(env_vars["WORKSPACE_FILES_PATH"]).name)
+
     with ZipFile(zipFile, "w") as zipObj:
-        # we need to exclude workspace folder and all its content
-        dirs = [path for path in directory.glob("**/*") if not (path.match("workspace/*") or path.name == "workspace")]
-        for path in dirs:
+        for path in directory.glob("**/*"):
+            if any([path.match(f"{excluded_dir}/*") for excluded_dir in excluded_dirs]) or path.name in excluded_dirs:
+                continue
             if path.name == "python":
                 # We are in a virtual environment
                 venv_path = path.parent.parent  # ./<venv>/bin/python -> ./<venv>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ import configparser
 import os
 import pytest
 import shutil
+import yaml
 
 from click.testing import CliRunner
 from openhexa.cli.api import upload_pipeline
@@ -19,8 +20,12 @@ def test_upload_pipeline():
 
     runner = CliRunner()
     runner.invoke(pipelines_init, ["test_pipelines"])
-    pipeline_dir = os.path.join(Path.cwd(), "test_pipelines")
-    pipeline_zip_file_dir = os.path.join(Path.cwd(), "pipeline.zip")
+    pipeline_dir = Path.cwd() / "test_pipelines"
+    pipeline_zip_file_dir = Path.cwd() / "pipeline.zip"
+
+    # create a sample file inside workspace dir
+    with open(pipeline_dir / Path("workspace/dummy.txt"), "w") as test_file:
+        test_file.write("Test upload")
 
     with mock.patch("openhexa.cli.api.graphql") as mocked_graphql_client:
         upload_pipeline(config=config, pipeline_directory_path=pipeline_dir)
@@ -29,6 +34,39 @@ def test_upload_pipeline():
         with ZipFile(pipeline_zip_file_dir) as zip_file:
             with pytest.raises(KeyError):
                 zip_file.getinfo("workspace")
+
+    shutil.rmtree(pipeline_dir)
+    os.remove(pipeline_zip_file_dir)
+
+
+def test_upload_pipeline_custom_files_path():
+    # to enable zip file creation
+    config = configparser.ConfigParser()
+    config["openhexa"] = {"debug": True, "current_workspace": "test_workspace"}
+
+    runner = CliRunner()
+    runner.invoke(pipelines_init, ["test_pipelines"])
+    pipeline_dir = Path.cwd() / "test_pipelines"
+    pipeline_zip_file_dir = Path.cwd() / "pipeline.zip"
+
+    (pipeline_dir / Path("data")).mkdir()
+    # setup a custom path for files location in workspace.yaml
+    pipeline_configs = {"files": {"path": "./data"}}
+
+    with open(pipeline_dir / Path("workspace.yaml"), "w") as pipeline_configs_file:
+        pipeline_configs_file.write(yaml.dump(pipeline_configs))
+
+    # create a sample file inside custom dir
+    with open(pipeline_dir / Path("data/dummy.txt"), "w") as test_file:
+        test_file.write("Test upload with custom files path")
+
+    with mock.patch("openhexa.cli.api.graphql") as mocked_graphql_client:
+        upload_pipeline(config=config, pipeline_directory_path=pipeline_dir)
+        mocked_graphql_client.return_value = {"success": True, "errors": []}
+
+        with ZipFile(pipeline_zip_file_dir) as zip_file:
+            with pytest.raises(KeyError):
+                zip_file.getinfo("data")
 
     shutil.rmtree(pipeline_dir)
     os.remove(pipeline_zip_file_dir)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,34 @@
+import configparser
+import os
+import pytest
+import shutil
+
+from click.testing import CliRunner
+from openhexa.cli.api import upload_pipeline
+from openhexa.cli.cli import pipelines_init
+from pathlib import Path
+
+from unittest import mock
+from zipfile import ZipFile
+
+
+def test_upload_pipeline():
+    # to enable zip file creation
+    config = configparser.ConfigParser()
+    config["openhexa"] = {"debug": True, "current_workspace": "test_workspace"}
+
+    runner = CliRunner()
+    runner.invoke(pipelines_init, ["test_pipelines"])
+    pipeline_dir = os.path.join(Path.cwd(), "test_pipelines")
+    pipeline_zip_file_dir = os.path.join(Path.cwd(), "pipeline.zip")
+
+    with mock.patch("openhexa.cli.api.graphql") as mocked_graphql_client:
+        upload_pipeline(config=config, pipeline_directory_path=pipeline_dir)
+        mocked_graphql_client.return_value = {"success": True, "errors": []}
+
+        with ZipFile(pipeline_zip_file_dir) as zip_file:
+            with pytest.raises(KeyError):
+                zip_file.getinfo("workspace")
+
+    shutil.rmtree(pipeline_dir)
+    os.remove(pipeline_zip_file_dir)


### PR DESCRIPTION
Relative to [issue](https://github.com/BLSQ/openhexa-team/issues/496) : we now filter and prevent upload of workspace/ folder contents.