### PR TITLE
doc: Add docstrings for @pipeline and @parameter

### DIFF
--- a/openhexa/sdk/pipelines/parameter.py
+++ b/openhexa/sdk/pipelines/parameter.py
@@ -278,7 +278,37 @@ def parameter(
     required: bool = True,
     multiple: bool = False,
 ):
-    """parameter decorator."""
+    """Decorator that attaches a parameter to an OpenHexa pipeline.
+
+    This decorator must be used on a function decorated by the @pipeline decorator.
+
+    Parameters
+    ----------
+    code : str
+        The parameter identifier (must be unique for a given pipeline)
+    type : {str, int, bool, float}
+        The parameter Python type
+    name : str, optional
+        A name for the parameter (will be used instead of the code in the web interface)
+    choices : list, optional
+        An optional list or tuple of choices for the parameter (will be used to build a choice widget in the web
+        interface)
+    help : str, optional
+        An optional help text to be displayed in the web interface
+    default : any, optional
+        An optional default value for the parameter (should be of the type defined by the type parameter)
+    required : bool, default=True
+        Whether the parameter is mandatory
+    multiple : bool, default=True
+        Whether this parameter should be provided multiple values (if True, the value must be provided as a list of
+        values of the chosen type)
+
+    Returns
+    -------
+    typing.Callable
+        A decorator that returns the Pipeline with the paramter attached
+
+    """
 
     def decorator(fun):
         return FunctionWithParameter(

--- a/openhexa/sdk/pipelines/pipeline.py
+++ b/openhexa/sdk/pipelines/pipeline.py
@@ -30,6 +30,25 @@ class PipelineConfigError(Exception):
 def pipeline(
     code: str, *, name: str = None, timeout: int = None
 ) -> typing.Callable[[typing.Callable[..., typing.Any]], "Pipeline"]:
+    """Decorator that turns a Python function into an OpenHexa pipeline.
+
+    Parameters
+    ----------
+    code : str
+        An identifier for the pipeline (should be unique within the workspace where the pipeline is deployed)
+    name : str, optional
+        An optional name for the pipeline (will be used instead of the code in the web interface)
+    timeout : int, optional
+        An optional timeout, in seconds, after which the pipeline run will be terminated (if not provided, a default
+        timeout will be applied by the OpenHexa backend)
+
+    Returns
+    -------
+    typing.Callable
+        A decorator that returns a Pipeline
+
+    """
+
     if any(c not in string.ascii_lowercase + string.digits + "_-" for c in code):
         raise Exception("Pipeline name should contains only lower case letters, digits, '_' and '-'")
 
@@ -180,7 +199,8 @@ class Pipeline:
             os.environ.update(get_local_workspace_config(Path("/home/hexa/pipeline")))
 
         # User can run their pipeline using `python pipeline.py`. It's considered as a standalone usage of the library.
-        # Since we still support this use case for the moment, we'll try to load the workspace.yaml at the path of the file
+        # Since we still support this use case for the moment, we'll try to load the workspace.yaml
+        # at the path of the file
         elif get_environment() == Environments.STANDALONE:
             os.environ.update(get_local_workspace_config(Path(sys.argv[0]).parent))
 


### PR DESCRIPTION
This PR adds docstrings for the `@pipeline` and `@parameter` decorators, following the Numpy styleguide.