### PR TITLE
refacto(Connections): hide sensitive informations when printing  connection

### DIFF
--- a/openhexa/sdk/workspaces/connection.py
+++ b/openhexa/sdk/workspaces/connection.py
@@ -34,7 +34,7 @@ class S3Connection:
     bucket_name: str
 
     def __repr__(self):
-        return f"S3Connection(access_key_id='*******', secret_access_key='*******', bucket_name='{self.bucket_name}')"
+        return f"S3Connection(bucket_name='{self.bucket_name}')"
 
 
 @dataclasses.dataclass
@@ -43,4 +43,4 @@ class GCSConnection:
     bucket_name: str
 
     def __repr__(self):
-        return f"GCSConnection(service_account_key='*******', bucket_name='{self.bucket_name}')"
+        return f"GCSConnection(bucket_name='{self.bucket_name}')"

--- a/openhexa/sdk/workspaces/connection.py
+++ b/openhexa/sdk/workspaces/connection.py
@@ -7,6 +7,9 @@ class DHIS2Connection:
     username: str
     password: str
 
+    def __repr__(self):
+        return f"DHIS2Connection(url='{self.url}', username='{self.username}', password='*********')"
+
 
 @dataclasses.dataclass
 class PostgreSQLConnection:
@@ -15,6 +18,9 @@ class PostgreSQLConnection:
     username: str
     password: str
     database_name: str
+
+    def __repr__(self):
+        return f"PostgreSQLConnection(host='{self.host}', port='{self.port}', username='{self.username}', password='*********', database_name='{self.database_name}')"
 
     @property
     def url(self):
@@ -27,8 +33,14 @@ class S3Connection:
     secret_access_key: str
     bucket_name: str
 
+    def __repr__(self):
+        return f"S3Connection(access_key_id='*******', secret_access_key='*******', bucket_name='{self.bucket_name}')"
+
 
 @dataclasses.dataclass
 class GCSConnection:
     service_account_key: str
     bucket_name: str
+
+    def __repr__(self):
+        return f"GCSConnection(service_account_key='*******', bucket_name='{self.bucket_name}')"

--- a/openhexa/sdk/workspaces/connection.py
+++ b/openhexa/sdk/workspaces/connection.py
@@ -8,7 +8,7 @@ class DHIS2Connection:
     password: str
 
     def __repr__(self):
-        return f"DHIS2Connection(url='{self.url}', username='{self.username}', password='*********')"
+        return f"DHIS2Connection(url='{self.url}', username='{self.username}')"
 
 
 @dataclasses.dataclass
@@ -20,7 +20,7 @@ class PostgreSQLConnection:
     database_name: str
 
     def __repr__(self):
-        return f"PostgreSQLConnection(host='{self.host}', port='{self.port}', username='{self.username}', password='*********', database_name='{self.database_name}')"
+        return f"PostgreSQLConnection(host='{self.host}', port='{self.port}', username='{self.username}', database_name='{self.database_name}')"
 
     @property
     def url(self):

--- a/openhexa/sdk/workspaces/workspace.py
+++ b/openhexa/sdk/workspaces/workspace.py
@@ -177,7 +177,13 @@ class CurrentWorkspace:
             if key.startswith(env_variable_prefix):
                 field_key = key[len(f"{env_variable_prefix}_") :].lower()
                 fields[field_key] = value
-        CustomConnection = make_dataclass(identifier, fields.keys())
+
+        dataclass = make_dataclass(identifier, fields.keys())
+
+        class CustomConnection(dataclass):
+            def __repr__(self):
+                return f"CustomConnection(name='{identifier}')"
+
         return CustomConnection(**fields)
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,10 +1,10 @@
 import os
-from unittest import mock
-
 import pytest
+import re
 import stringcase
 
 from openhexa.sdk.workspaces.workspace import ConnectionDoesNotExist, workspace
+from unittest import mock
 
 
 def test_workspace_dhis2_connection_not_exist():
@@ -31,6 +31,8 @@ def test_workspace_dhis2_connection():
         assert dhis2_connection.url == url
         assert dhis2_connection.username == username
         assert dhis2_connection.password == password
+        assert re.search("password", repr(dhis2_connection)) is None
+        assert re.search("password", str(dhis2_connection)) is None
 
 
 def test_workspace_postgresql_connection_not_exist():
@@ -65,6 +67,8 @@ def test_workspace_postgresql_connection():
         assert postgres_connection.port == int(port)
         assert postgres_connection.database_name == database_name
         assert postgres_connection.url == url
+        assert re.search("password", repr(postgres_connection)) is None
+        assert re.search("password", str(postgres_connection)) is None
 
 
 def test_workspace_S3_connection_not_exist():
@@ -92,6 +96,10 @@ def test_workspace_s3_connection():
         assert s3_connection.secret_access_key == secret_access_key
         assert s3_connection.access_key_id == access_key_id
         assert s3_connection.bucket_name == bucket_name
+        assert re.search("secret_access_key", repr(s3_connection)) is None
+        assert re.search("secret_access_key", str(s3_connection)) is None
+        assert re.search("access_key_id", repr(s3_connection)) is None
+        assert re.search("access_key_id", str(s3_connection)) is None
 
 
 def test_workspace_gcs_connection_not_exist():
@@ -116,6 +124,8 @@ def test_workspace_gcs_connection():
         s3_connection = workspace.gcs_connection(identifier=identifier)
         assert s3_connection.service_account_key == service_account_key
         assert s3_connection.bucket_name == bucket_name
+        assert re.search("service_account_key", repr(s3_connection)) is None
+        assert re.search("service_account_key", str(s3_connection)) is None
 
 
 def test_workspace_custom_connection():

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -144,6 +144,8 @@ def test_workspace_custom_connection():
         custom_connection = workspace.custom_connection(identifier=identifier)
         assert custom_connection.username == username
         assert custom_connection.password == password
+        assert re.search(f"{env_variable_prefix}_PASSWORD", repr(custom_connection)) is None
+        assert re.search(f"{env_variable_prefix}_PASSWORD", str(custom_connection)) is None
 
 
 def test_connection_by_slug_warning():


### PR DESCRIPTION
Relative to [issue](https://github.com/BLSQ/openhexa-team/issues/512) : hide sensitive informations when printing  connection