### PR TITLE
feat: Add tmp_path property on workspace

### DIFF
--- a/openhexa/sdk/pipelines/utils.py
+++ b/openhexa/sdk/pipelines/utils.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from tempfile import mkdtemp
 
 import stringcase
 import yaml
@@ -19,6 +20,7 @@ def get_local_workspace_config(path: Path):
     """
 
     env_vars = {}
+
     # This will only work when running the pipeline using "python pipeline.py"
     # (We will have to find another approach for tests or running the pipeline using the CLI)
     local_workspace_config_path = path / Path("workspace.yaml")
@@ -62,6 +64,9 @@ def get_local_workspace_config(path: Path):
                     "keys: username, password, host, port, name."
                 )
                 raise LocalWorkspaceConfigError(exception_message)
+
+            # Create temp dir to simulate /home/hexa/tmp locally
+            env_vars["WORKSPACE_TMP_PATH"] = mkdtemp()
 
         # Connections
         if "connections" in local_workspace_config:

--- a/openhexa/sdk/workspaces/workspace.py
+++ b/openhexa/sdk/workspaces/workspace.py
@@ -101,10 +101,15 @@ class CurrentWorkspace:
 
         # FIXME: This is a hack to make the SDK work in the context of the `python pipeline.py` command.
         # We can remove this once we deprecate this way of running pipelines
-        if "WORKSPACE_FILES_PATH" in os.environ:
-            return os.environ["WORKSPACE_FILES_PATH"]
-        else:
-            return "/home/hexa/workspace"
+        return os.environ["WORKSPACE_FILES_PATH"] if "WORKSPACE_FILES_PATH" in os.environ else "/home/hexa/workspace"
+
+    @property
+    def tmp_path(self) -> str:
+        """Return the base path to the tmp directory, without trailing slash"""
+
+        # FIXME: This is a hack to make the SDK work in the context of the `python pipeline.py` command.
+        # We can remove this once we deprecate this way of running pipelines
+        return os.environ["WORKSPACE_TMP_PATH"] if "WORKSPACE_TMP_PATH" in os.environ else "/home/hexa/tmp"
 
     def dhis2_connection(self, identifier: str = None, slug: str = None) -> DHIS2Connection:
         identifier = identifier or slug

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,10 +1,27 @@
 import os
+from tempfile import mkdtemp
+
 import pytest
 import re
 import stringcase
 
 from openhexa.sdk.workspaces.workspace import ConnectionDoesNotExist, workspace
 from unittest import mock
+
+
+def test_workspace_files_path(monkeypatch):
+    assert workspace.files_path == "/home/hexa/workspace"
+
+    monkeypatch.setenv("WORKSPACE_FILES_PATH", "/Users/John/openhexa/project-1/workspace")
+    assert workspace.files_path == "/Users/John/openhexa/project-1/workspace"
+
+
+def test_workspace_tmp_path(monkeypatch):
+    assert workspace.tmp_path == "/home/hexa/tmp"
+
+    mock_tmp_path = mkdtemp()
+    monkeypatch.setenv("WORKSPACE_TMP_PATH", mock_tmp_path)
+    assert workspace.tmp_path == mock_tmp_path
 
 
 def test_workspace_dhis2_connection_not_exist():


### PR DESCRIPTION
Same as `workspace.files_path` but for `/home/hexa/tmp/`.