### PR TITLE
feat: Add support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,17 @@ jobs:
   test:
     name: Run test suite
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.9", "3.10", "3.11" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-  
-      - name: Set up Python
+
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       
       - name: "Install dependencies"
         run: pip install ".[dev]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"
 ]
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.9,<3.12"  # the main constraint for supported Python versions is the multiprocess library
 dependencies = [
     "multiprocess~=0.70.15",
     "requests~=2.28.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"
 ]
-requires-python = ">=3.9,<3.11"
+requires-python = ">=3.9,<3.12"
 dependencies = [
-    "multiprocess~=0.70.14",
+    "multiprocess~=0.70.15",
     "requests~=2.28.2",
     "PyYAML~=6.0",
     "stringcase~=1.2.0",


### PR DESCRIPTION
This PR:

- Adds support for Python 3.11
- Linked: updates `multiprocess` to latest version which supports Python 3.11
- Adds a Python version matrix to the test workflow