### PR TITLE
feat(Workspaces): allow user to specify workspace docker image

### DIFF
--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -410,6 +410,8 @@ def pipelines_run(
     if force_pull:
         cmd.extend(["--pull", "always"])
 
+    image = env_vars["WORKSPACE_DOCKER_IMAGE"] if env_vars.get("WORKSPACE_DOCKER_IMAGE") else image
+
     cmd.extend(
         [
             image,

--- a/openhexa/sdk/pipelines/utils.py
+++ b/openhexa/sdk/pipelines/utils.py
@@ -147,4 +147,8 @@ def get_local_workspace_config(path: Path):
                     for key, value in connection_config.items():
                         if key != "type":
                             env_vars[stringcase.constcase(f"{slug}_{key.lower()}")] = str(value)
+        # Workspace docker image
+        if "image" in local_workspace_config:
+            env_vars["WORKSPACE_DOCKER_IMAGE"] = local_workspace_config["image"]
+
     return env_vars


### PR DESCRIPTION
Allow users to specifiy workspace docker image (name & tag)  in workspace.yaml when running pipeline in local with `openhexa pipelines run`.