### PR TITLE
fix(Docker): Always force pull the image

### DIFF
--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -10,6 +10,7 @@ import stringcase
 from openhexa.cli.api import (
     InvalidDefinitionError,
     create_pipeline,
+    delete_pipeline,
     ensure_is_pipeline_dir,
     get_pipeline,
     get_pipelines,
@@ -18,7 +19,6 @@ from openhexa.cli.api import (
     open_config,
     save_config,
     upload_pipeline,
-    delete_pipeline,
 )
 from openhexa.cli.utils import terminate
 from openhexa.sdk.pipelines import get_local_workspace_config, import_pipeline
@@ -370,13 +370,11 @@ def pipelines_delete(code: str):
     help="Configuration JSON file",
 )
 @click.option("--image", type=str, help="Docker image to use", default="blsq/openhexa-base-notebook:latest")
-@click.option("--force-pull", is_flag=True, help="Force pull of the docker image", default=False)
 def pipelines_run(
     path: str,
     image: str,
     config_str: str = "{}",
     config_file: click.File = None,
-    force_pull=False,
 ):
     """
     Run a pipeline locally.
@@ -405,10 +403,9 @@ def pipelines_run(
         "--platform",
         "linux/amd64",
         "--rm",
+        "--pull",
+        "always",
     ]
-
-    if force_pull:
-        cmd.extend(["--pull", "always"])
 
     image = env_vars["WORKSPACE_DOCKER_IMAGE"] if env_vars.get("WORKSPACE_DOCKER_IMAGE") else image
 


### PR DESCRIPTION
Users were complaining the image was not the latest one. The default behavior should be to always download the latest image instead