### PR TITLE
feat(Parameter): add support for Dataset parameter type

### DIFF
--- a/openhexa/sdk/__init__.py
+++ b/openhexa/sdk/__init__.py
@@ -1,5 +1,6 @@
 """SDK package."""
 
+from .datasets import Dataset
 from .pipelines import current_run, parameter, pipeline
 from .workspaces import workspace
 from .workspaces.connection import (
@@ -22,4 +23,5 @@ __all__ = [
     "GCSConnection",
     "S3Connection",
     "CustomConnection",
+    "Dataset",
 ]

--- a/openhexa/sdk/pipelines/parameter.py
+++ b/openhexa/sdk/pipelines/parameter.py
@@ -211,7 +211,7 @@ class PostgreSQLConnectionType(ConnectionParameterType):
     @property
     def expected_type(self) -> type:
         """Returns the python type expected for values."""
-        return PostgreSQLConnectionType
+        return PostgreSQLConnection
 
     def to_connection(self, value: str) -> PostgreSQLConnection:
         """Build a PostgreSQL connection instance from the provided value (which should be a connection identifier)."""
@@ -229,7 +229,7 @@ class S3ConnectionType(ConnectionParameterType):
     @property
     def expected_type(self) -> type:
         """Returns the python type expected for values."""
-        return S3ConnectionType
+        return S3Connection
 
     def to_connection(self, value: str) -> S3Connection:
         """Build a S3 connection instance from the provided value (which should be a connection identifier)."""
@@ -247,7 +247,7 @@ class GCSConnectionType(ConnectionParameterType):
     @property
     def expected_type(self) -> type:
         """Returns the python type expected for values."""
-        return GCSConnectionType
+        return GCSConnection
 
     def to_connection(self, value: str) -> GCSConnection:
         """Build a GCS connection instance from the provided value (which should be a connection identifier)."""
@@ -265,7 +265,7 @@ class DHIS2ConnectionType(ConnectionParameterType):
     @property
     def expected_type(self) -> type:
         """Returns the python type expected for values."""
-        return DHIS2ConnectionType
+        return DHIS2Connection
 
     def to_connection(self, value: str) -> DHIS2Connection:
         """Build a DHIS2 connection instance from the provided value (which should be a connection identifier)."""
@@ -283,7 +283,7 @@ class IASOConnectionType(ConnectionParameterType):
     @property
     def expected_type(self) -> type:
         """Returns the python type expected for values."""
-        return IASOConnectionType
+        return IASOConnection
 
     def to_connection(self, value: str) -> IASOConnection:
         """Build a IASO connection instance from the provided value (which should be a connection identifier)."""
@@ -301,7 +301,7 @@ class CustomConnectionType(ConnectionParameterType):
     @property
     def expected_type(self) -> type:
         """Returns the python type expected for values."""
-        return CustomConnectionType
+        return CustomConnection
 
     def to_connection(self, value: str) -> CustomConnection:
         """Build a custom connection instance from the provided value (which should be a connection identifier)."""
@@ -319,7 +319,17 @@ class DatasetType(ParameterType):
     @property
     def expected_type(self) -> type:
         """Returns the python type expected for values."""
-        return DatasetType
+        return Dataset
+
+    def validate_default(self, value: typing.Optional[typing.Any]):
+        """Validate the default value configured for this type."""
+        if value is None:
+            return
+
+        if not isinstance(value, str):
+            raise InvalidParameterError("Default value for dataset parameter type should be string.")
+        elif value == "":
+            raise ParameterValueError("Empty values are not accepted.")
 
     def validate(self, value: typing.Optional[typing.Any]) -> Dataset:
         """Validate the provided value for this type."""
@@ -327,13 +337,9 @@ class DatasetType(ParameterType):
             raise ParameterValueError(f"Invalid type for value {value} (expected {str}, got {type(value)})")
 
         try:
-            return self.to_dataset(value)
+            return workspace.get_dataset(value)
         except ValueError as e:
             raise ParameterValueError(str(e))
-
-    def to_dataset(self, value: str) -> CustomConnection:
-        """Build a dataset instance from the provided value (which should be a dataset identifier)."""
-        return workspace.get_dataset(value)
 
 
 TYPES_BY_PYTHON_TYPE = {

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -7,6 +7,7 @@ import pytest
 import stringcase
 
 from openhexa.sdk import (
+    Dataset,
     DHIS2Connection,
     GCSConnection,
     IASOConnection,
@@ -17,6 +18,7 @@ from openhexa.sdk import (
 from openhexa.sdk.pipelines.parameter import (
     Boolean,
     CustomConnectionType,
+    DatasetType,
     DHIS2ConnectionType,
     Float,
     FunctionWithParameter,
@@ -222,6 +224,22 @@ def test_validate_custom_connection():
         assert str(custom_co) == str(_custom_co)
         with pytest.raises(ParameterValueError):
             custom_co_type.validate(86)
+
+
+@mock.patch("openhexa.sdk.workspace.get_dataset")
+def test_validate_dataset_parameter(mock_get_dataset):
+    """Check Dataset parameter validation."""
+    identifier = "dataset-slug"
+
+    dataset = Dataset(id="id", slug=identifier, name="name", description="Description")
+
+    mock_get_dataset.return_value = dataset
+
+    dataset_type = DatasetType()
+
+    assert dataset_type.validate(identifier) == dataset
+    with pytest.raises(ParameterValueError):
+        dataset_type.validate(86)
 
 
 def test_parameter_init():


### PR DESCRIPTION
Add support for dataset parameter type in sdk. As we have done for the connection, user can now define parameter of type dataset via @parameter("dataset_identifier",....). The corresponding dataset instance will be automatically injected and available to use.