### PR TITLE
feat(CLI): check if permission_denied is thrown

### DIFF
--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -31,6 +31,12 @@ class PipelineDefinitionErrorCode(enum.Enum):
     INVALID_TIMEOUT_VALUE = "INVALID_TIMEOUT_VALUE"
 
 
+class PermissionDenied(Exception):
+    """Raised whenever an operation on a pipeline is denied by the backend."""
+
+    pass
+
+
 def is_debug(config: ConfigParser) -> bool:
     """Determine whether the provided configuration has the debug flag."""
     return config.getboolean("openhexa", "debug", fallback=False)
@@ -218,6 +224,11 @@ def delete_pipeline(config, pipeline_id: str):
     )
 
     if not data["deletePipeline"]["success"]:
+        if "PERMISSION_DENIED" in data["deletePipeline"]["errors"]:
+            raise Exception(
+                "Check that you have the correct permission or the pipeline is not in a queued/running state."
+            )
+
         raise Exception(data["deletePipeline"]["errors"])
 
     return data["deletePipeline"]["success"]

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -313,25 +313,13 @@ def pipelines_delete(code: str):
             )
             sys.exit(1)
 
-        confirmation_code = click.prompt(
-            f'This will remove the pipeline "{click.style(code, bold=True)}" from the "{click.style(workspace, bold=True)} workspace. This operation cannot be undone.\nPlease enter "{click.style(code, bold=True)}" to confirm',
-            type=str,
-        )
-
-        if confirmation_code != code:
-            click.echo(
-                "Pipeline code and confirmation are different, aborted.",
-                err=True,
-            )
-            sys.exit(1)
-
         try:
             if delete_pipeline(user_config, pipeline["id"]):
                 click.echo(f"Pipeline {click.style(code, bold=True)} deleted.")
 
         except Exception as e:
             _terminate(
-                f'Error while deleting pipeline: "{e}"',
+                f'Error while deleting pipeline {code}: "{e}"',
                 err=True,
                 exception=e,
                 debug=is_debug(user_config),


### PR DESCRIPTION
When deleting a pipeline we now throw an error if the pipeline is in Running or Queued state and show a message to prevent the user.