### PR TITLE
fix(urllib): Use urllib < 2 to avoid problemw with openssl being not uptodate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.9,<3.13" # the main constraint for supported Python versions is the multiprocess library
 dependencies = [
+    "urllib3<2",
     "multiprocess~=0.70.15",
     "requests>=2.31,<2.33",
     "PyYAML~=6.0",


### PR DESCRIPTION
The problem is encountered on our users' computer. As we do not use the latest features of urllib and the package still receives security updates, it's safe to pin a older version for now.