### PR TITLE
fix: copy workspace folder to correct path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ Great! As you can see in the console output, the OpenHEXA CLI has created a new 
 structure required for an OpenHEXA pipeline. You can now `cd` in the new pipeline directory and run the pipeline:
 
 ```shell
-cd my_awesome_pipeline
-python pipeline.py
+openhexa pipelines run ./my_awesome_pipeline
 ```
 
 Congratulations! You have successfully run your first pipeline locally.

--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -346,10 +346,7 @@ def run_pipeline(path: Path, config: dict, image: str = None, debug: bool = Fals
     tmp_dir = tempfile.mkdtemp()
     for file_path in path.glob("**/*"):
         if file_path.suffix in (".py", ".ipynb", ".txt", ".md", ".yaml"):
-            relative_path = file_path.relative_to(path)
-            destination_path = Path(tmp_dir) / relative_path
-            destination_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy(file_path, destination_path)
+            shutil.copy(file_path, tmp_dir)
 
     volumes = {
         tmp_dir: {"bind": "/home/hexa/pipeline", "mode": "rw"},

--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -346,7 +346,10 @@ def run_pipeline(path: Path, config: dict, image: str = None, debug: bool = Fals
     tmp_dir = tempfile.mkdtemp()
     for file_path in path.glob("**/*"):
         if file_path.suffix in (".py", ".ipynb", ".txt", ".md", ".yaml"):
-            shutil.copy(file_path, tmp_dir)
+            relative_path = file_path.relative_to(path)
+            destination_path = Path(tmp_dir) / relative_path
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(file_path, destination_path)
 
     volumes = {
         tmp_dir: {"bind": "/home/hexa/pipeline", "mode": "rw"},

--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -351,7 +351,7 @@ def run_pipeline(path: Path, config: dict, image: str = None, debug: bool = Fals
     volumes = {
         tmp_dir: {"bind": "/home/hexa/pipeline", "mode": "rw"},
         mount_files_path: {
-            "bind": "/home/hexa/pipeline/workspace",
+            "bind": "/home/hexa/workspace",
             "mode": "rw",
         },
     }

--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -351,7 +351,7 @@ def run_pipeline(path: Path, config: dict, image: str = None, debug: bool = Fals
     volumes = {
         tmp_dir: {"bind": "/home/hexa/pipeline", "mode": "rw"},
         mount_files_path: {
-            "bind": "/home/hexa/workspace",
+            "bind": "/home/hexa/pipeline/workspace",
             "mode": "rw",
         },
     }

--- a/openhexa/sdk/pipelines/pipeline.py
+++ b/openhexa/sdk/pipelines/pipeline.py
@@ -202,14 +202,10 @@ class Pipeline:
         This method can be called with an explicit configuration. If no configuration is provided, it will parse the
         command-line arguments to build it.
         """
-        # Handle local workspace config for dev / testing, if appropriate
-        if get_environment() == Environment.LOCAL_PIPELINE:
-            os.environ.update(get_local_workspace_config(Path("/home/hexa/pipeline")))
-
         # User can run their pipeline using `python pipeline.py`. It's considered as a standalone usage of the library.
         # Since we still support this use case for the moment, we'll try to load the workspace.yaml
         # at the path of the file
-        elif get_environment() == Environment.STANDALONE:
+        if get_environment() == Environment.STANDALONE:
             os.environ.update(get_local_workspace_config(Path(sys.argv[0]).parent))
 
         if config is None:  # Called without arguments, in the pipeline file itself

--- a/openhexa/sdk/pipelines/utils.py
+++ b/openhexa/sdk/pipelines/utils.py
@@ -68,10 +68,9 @@ def get_local_workspace_config(path: Path):
         if "files" in local_workspace_config:
             try:
                 files_path = path / Path(local_workspace_config["files"]["path"])
-                if not files_path.exists():
-                    # When we start the pipeline container, we mount the workspace folder,
-                    # if it doesn't exist, it means we don't provide the correct mount path, which is the case in local
-                    files_path = Path("/home/hexa/workspace")
+                if files_path.exists() is False:
+                    # Let's create the folder if it doesn't exist
+                    files_path.mkdir(parents=True)
                 env_vars["WORKSPACE_FILES_PATH"] = str(files_path.resolve())
             except KeyError:
                 exception_message = (

--- a/openhexa/sdk/pipelines/utils.py
+++ b/openhexa/sdk/pipelines/utils.py
@@ -69,8 +69,9 @@ def get_local_workspace_config(path: Path):
             try:
                 files_path = path / Path(local_workspace_config["files"]["path"])
                 if not files_path.exists():
-                    # Let's create the folder if it doesn't exist
-                    files_path.mkdir(parents=True)
+                    # When we start the pipeline container, we mount the workspace folder,
+                    # if it doesn't exist, it means we don't provide the correct mount path, which is the case in local
+                    files_path = Path("/home/hexa/workspace")
                 env_vars["WORKSPACE_FILES_PATH"] = str(files_path.resolve())
             except KeyError:
                 exception_message = (

--- a/openhexa/sdk/pipelines/utils.py
+++ b/openhexa/sdk/pipelines/utils.py
@@ -69,7 +69,7 @@ def get_local_workspace_config(path: Path):
             try:
                 files_path = path / Path(local_workspace_config["files"]["path"])
                 if files_path.exists() is False:
-                    # Let's create the folder if it doesn't exist
+                    # Let's create the folder if it doesn't exist (only needed when running the pipeline using `python pipeline.py`)
                     files_path.mkdir(parents=True)
                 env_vars["WORKSPACE_FILES_PATH"] = str(files_path.resolve())
             except KeyError:

--- a/openhexa/sdk/workspaces/current_workspace.py
+++ b/openhexa/sdk/workspaces/current_workspace.py
@@ -137,8 +137,8 @@ class CurrentWorkspace:
         /home/hexa/workspace/some/path
         """
         # FIXME: This is a hack to make the SDK work in the context of the `python pipeline.py` command.
-        # We can remove this once we deprecate this way of running pipelines
-        return os.environ["WORKSPACE_FILES_PATH"] if "WORKSPACE_FILES_PATH" in os.environ else "/home/hexa/workspace"
+        # We can remove this once we deprecate this way of running pipelines and only use /home/hexa/workspace
+        return os.environ.get("WORKSPACE_FILES_PATH", "/home/hexa/workspace")
 
     @property
     def tmp_path(self) -> str:


### PR DESCRIPTION
When we work locally we provide path "/home/hexa/pipeline" to search for configuration and file_path, which is incorrect.