### PR TITLE
fix: Remove slash from api_url

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+A short, meaningful PR description. Explain the goal of the PR and the ideas behind it.
+
+## Changes
+
+Please list / describe the changes in the codebase for the reviewer(s).
+
+- Change 1
+- Change 2
+
+## How/what to test
+
+A few words about what needs to be tested, along with specific testing instructions if needed.
+
+## Screenshots / screencast
+
+If relevant, please add some screenshots or a short video.

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# IDE
-.idea/

--- a/openhexa/cli/settings.py
+++ b/openhexa/cli/settings.py
@@ -53,15 +53,13 @@ class Settings:
         """Return the API URL from the settings file or environment variables."""
         url_from_env = os.getenv("HEXA_API_URL") or os.getenv("HEXA_SERVER_URL")
         if url_from_env is None:
-            return self._file_config["openhexa"]["url"]
+            url_from_env = self._file_config["openhexa"]["url"]
+        return url_from_env.rstrip("/")
 
     @property
     def public_api_url(self):
         """Return the public API URL from the settings file or environment variables."""
-        url_from_env = os.getenv("HEXA_API_URL") or os.getenv("HEXA_SERVER_URL")
-        if url_from_env is not None:
-            return url_from_env
-        return self._file_config["openhexa"]["url"].replace("api", "app")
+        return self.api_url.replace("api", "app")
 
     @property
     def current_workspace(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from io import BytesIO
 from pathlib import Path
 from tempfile import mkdtemp
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 from zipfile import ZipFile
 
 import pytest
@@ -22,7 +22,7 @@ pipeline_name = "MyPipeline"
 
 
 def create_zip_with_pipeline():
-    """Helper method to create a zip file containing the pipeline.py file."""
+    """Create a zip file containing the pipeline.py file."""
     zip_buffer = BytesIO()
     fake_zipfile = ZipFile(zip_buffer, "w")
     fake_zipfile.writestr(python_file_name, python_code)
@@ -30,15 +30,11 @@ def create_zip_with_pipeline():
     return zip_buffer
 
 
-def setup_graphql_response(zip_buffer = create_zip_with_pipeline()):
-    """Helper method to set up the mock GraphQL response pipelines."""
+def setup_graphql_response(zip_buffer=create_zip_with_pipeline()):
+    """Set up the mock GraphQL response pipelines."""
     return {
-        "pipelineByCode": {
-            "currentVersion": {
-                "zipfile": base64.b64encode(zip_buffer.getvalue()).decode()
-            }
-        },
-        "pipelines": {"items": []}  # (empty workspace initially)
+        "pipelineByCode": {"currentVersion": {"zipfile": base64.b64encode(zip_buffer.getvalue()).decode()}},
+        "pipelines": {"items": []},  # (empty workspace initially)
     }
 
 
@@ -120,7 +116,7 @@ class CliRunTest(TestCase):
     @patch("openhexa.cli.api.graphql")
     @patch("openhexa.cli.cli.get_pipeline")
     @patch("openhexa.cli.cli.upload_pipeline")
-    @patch.dict(os.environ, {"HEXA_API_URL": "https://www.bluesquarehub.com/","HEXA_WORKSPACE": "workspace"})
+    @patch.dict(os.environ, {"HEXA_API_URL": "https://www.bluesquarehub.com/", "HEXA_WORKSPACE": "workspace"})
     def test_push_pipeline(self, mock_upload_pipeline, mock_get_pipeline, mock_graphql):
         """Test pushing a pipeline."""
         with self.runner.isolated_filesystem() as tmp:
@@ -131,10 +127,15 @@ class CliRunTest(TestCase):
             mock_pipeline.code = pipeline_name
             mock_get_pipeline.return_value = mock_pipeline
 
-            result = self.runner.invoke(pipelines_push,  [tmp, '--name', version])
+            result = self.runner.invoke(pipelines_push, [tmp, "--name", version])
             self.assertEqual(result.exit_code, 0)
-            self.assertIn ((f'✅ New version \'{version}\' created! '
-                    f'You can view the pipeline in OpenHEXA on https://www.bluesquarehub.com/workspaces/workspace/pipelines/{pipeline_name}'), result.output)
+            self.assertIn(
+                (
+                    f"✅ New version '{version}' created! "
+                    f"You can view the pipeline in OpenHEXA on https://www.bluesquarehub.com/workspaces/workspace/pipelines/{pipeline_name}"
+                ),
+                result.output,
+            )
             self.assertTrue(mock_upload_pipeline.called)
 
     @patch("openhexa.cli.api.graphql")


### PR DESCRIPTION
When pushing a pipeline using the SDK, I was getting `http://localhost:8000//workspaces/test/pipelines/simple-etl` which contains an extra slash.  This PR fixes the issue, adds a unit test to cover the change and some parts of `pipelines_push` method.

## Changes

- Strip the slash in the url method
- Reuse the api_url method to compute the public api url
- Add a unit test to cover the push method
- Refactor the unit tests to avoid duplication of code and constants
- Add the Pr template from other repos

## How/what to test

- Pushing a pipeline works with and without slash at the end of the config url
- Unit test are still passing
