### PR TITLE
feat!: Set a default version number for each pipeline version, make version name optional

### DIFF
--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -531,7 +531,7 @@ def generate_zip_file(pipeline_directory_path: typing.Union[str, Path]) -> io.By
 
 def upload_pipeline(
     pipeline_directory_path: typing.Union[str, Path],
-    name: str,
+    name: str = None,
     description: str = None,
     link: str = None,
 ):
@@ -561,7 +561,7 @@ def upload_pipeline(
                     errors
                     pipelineVersion {
                         id
-                        name
+                        versionName
                     }
                 }
             }

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -321,7 +321,7 @@ def pipelines_push(
             uploaded_pipeline = upload_pipeline(path, name, description=description, link=link)
             click.echo(
                 click.style(
-                    f"✅ New version '{uploaded_pipeline["versionName"]}' created! You can view the pipeline in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/pipelines/{pipeline.code}', fg='bright_blue', underline=True)}",
+                    f"✅ New version '{uploaded_pipeline['versionName']}' created! You can view the pipeline in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/pipelines/{pipeline.code}', fg='bright_blue', underline=True)}",
                     fg="green",
                 )
             )

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -313,7 +313,7 @@ def pipelines_push(
             name_text = f" with name {click.style(name, bold=True)}" if name else ""
             confirmation_message = (
                 f"Pushing pipeline {click.style(pipeline.code, bold=True)} "
-                f"to workspace {click.style(workspace, bold=True)}{name_text}?"
+                f"to workspace {click.style(workspace, bold=True)}{name_text} ?"
             )
             click.confirm(confirmation_message, default=True, abort=True)
 

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -237,10 +237,11 @@ def pipelines_init(name: str):
 @click.option(
     "--name",
     "-n",
+    default=None,
     type=str,
     help="Name of the version",
     prompt="Name of the version",
-    required=True,
+    prompt_required=False,
 )
 @click.option(
     "--description",
@@ -263,7 +264,7 @@ def pipelines_init(name: str):
 @click.option("--yes", is_flag=True, help="Skip confirmation")
 def pipelines_push(
     path: str,
-    name: str,
+    name: str = None,
     description: str = None,
     link: str = None,
     yes: bool = False,
@@ -309,17 +310,18 @@ def pipelines_push(
                 )
             create_pipeline(pipeline.code, pipeline.name)
         elif not yes:
-            click.confirm(
-                f"Pushing pipeline {click.style(pipeline.code, bold=True)} to workspace {click.style(workspace, bold=True)} with name {click.style(name, bold=True)}?",
-                True,
-                abort=True,
+            name_text = f" with name {click.style(name, bold=True)}" if name else ""
+            confirmation_message = (
+                f"Pushing pipeline {click.style(pipeline.code, bold=True)} "
+                f"to workspace {click.style(workspace, bold=True)}{name_text}?"
             )
+            click.confirm(confirmation_message, default=True, abort=True)
 
         try:
-            upload_pipeline(path, name, description=description, link=link)
+            uploaded_pipeline = upload_pipeline(path, name, description=description, link=link)
             click.echo(
                 click.style(
-                    f"✅ New version '{name}' created! You can view the pipeline in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/pipelines/{pipeline.code}', fg='bright_blue', underline=True)}",
+                    f"✅ New version '{uploaded_pipeline["versionName"]}' created! You can view the pipeline in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/pipelines/{pipeline.code}', fg='bright_blue', underline=True)}",
                     fg="green",
                 )
             )

--- a/openhexa/sdk/pipelines/runtime.py
+++ b/openhexa/sdk/pipelines/runtime.py
@@ -50,7 +50,7 @@ def download_pipeline(url: str, token: str, run_id: str, target_dir: str):
               pipelineRun(id: $id) {
                 id
                 version {
-                  number
+                  versionNumber
                 }
                 code
               }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,6 +126,7 @@ class CliRunTest(TestCase):
             mock_pipeline = MagicMock(spec=Pipeline)
             mock_pipeline.code = pipeline_name
             mock_get_pipeline.return_value = mock_pipeline
+            mock_upload_pipeline.return_value = {"versionName": version}
 
             result = self.runner.invoke(pipelines_push, [tmp, "--name", version])
             self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
PR related to https://github.com/BLSQ/openhexa-app/pull/857

Pipeline versions should auto-increment, a name for the version should be optional

## Changes

- Make the name otpional
- Get and show the pipeline version number

## How/what to test

- Pushing a pipeline can be done with and without version name 

## Screenshots / screencast

![Screenshot 2024-11-22 at 11 16 34](https://github.com/user-attachments/assets/d0c23764-bf9c-46f4-9639-64168708b7b5)
