### PR TITLE
feat: Support template version creation on push (HEXA-1182)

### DIFF
--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -625,9 +625,14 @@ def create_pipeline_template_version(
         createPipelineTemplateVersion(input: $input) {
             success
             errors
-            pipelineTemplateVersion {
+            pipelineTemplate {
                 id
-                versionName
+                name
+                code
+                currentVersion {
+                    id
+                    versionNumber
+                }
             }
         }
     }
@@ -665,4 +670,4 @@ def create_pipeline_template_version(
         else:
             raise Exception(data["createPipelineTemplateVersion"]["errors"])
 
-    return data["createPipelineTemplateVersion"]["pipelineTemplateVersion"]
+    return data["createPipelineTemplateVersion"]["pipelineTemplate"]

--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -563,10 +563,13 @@ def upload_pipeline(
                         id
                         versionName
                         pipeline {
+                            id
                             permissions {
                                 createTemplateVersion
                             }
                             template {
+                                id
+                                code
                                 name
                             }
                         }

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -341,11 +341,12 @@ def pipelines_push(
             )
         uploaded_pipeline = uploaded_pipeline_version["pipeline"]
         if uploaded_pipeline["template"] and uploaded_pipeline["permissions"]["createTemplateVersion"]:
-            click.confirm(
-                f"The template {click.style(uploaded_pipeline['template']['name'], bold=True)} is based on this pipeline, do you want to publish a new version of the template as well ?",
-                True,
-                abort=True,
-            )
+            if not yes:
+                click.confirm(
+                    f"The template {click.style(uploaded_pipeline['template']['name'], bold=True)} is based on this pipeline, do you want to publish a new version of the template as well ?",
+                    True,
+                    abort=True,
+                )
             click.echo("Please provide an optional changelog for the new version of the template:")
             changelog = click.prompt("Changelog", type=str)
             try:

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -245,9 +245,10 @@ def propose_to_create_template_version(workspace, pipeline_version, yes):
         )
         try:
             template = create_pipeline_template_version(workspace, pipeline["id"], pipeline_version["id"], changelog)
+            template_code_url = urllib.parse.quote(template["code"])
             click.echo(
                 click.style(
-                    f"✅ New version '{template['currentVersion']['versionNumber']}' of the template '{template['name']}' created! You can view the new template version in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/templates/{urllib.parse.quote(template["code"])}/versions', fg='bright_blue', underline=True)}",
+                    f"✅ New version '{template['currentVersion']['versionNumber']}' of the template '{template['name']}' created! You can view the new template version in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/templates/{template_code_url}/versions', fg='bright_blue', underline=True)}",
                     fg="green",
                 )
             )

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -235,15 +235,20 @@ def handle_template_creation(workspace, uploaded_pipeline_version, yes):
                 True,
                 abort=True,
             )
-        click.echo("Please provide an optional changelog for the new version of the template:")
-        changelog = click.prompt("Changelog", type=str)
+        changelog = (
+            ""
+            if yes
+            else click.prompt(
+                f"{click.style("Changelog", bold=True)} (optional)", type=str, default="", show_default=False
+            )
+        )
         try:
             template = create_pipeline_template_version(
                 workspace, uploaded_pipeline["id"], uploaded_pipeline_version["id"], changelog
             )
             click.echo(
                 click.style(
-                    f"✅ New version '{template['currentVersion']['versionNumber']}' of the template '{template['name']}' created! You can view the new template version in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/templates/{template.code}/versions', fg='bright_blue', underline=True)}",
+                    f"✅ New version '{template['currentVersion']['versionNumber']}' of the template '{template['name']}' created! You can view the new template version in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/templates/{template['code']}/versions', fg='bright_blue', underline=True)}",
                     fg="green",
                 )
             )
@@ -255,43 +260,6 @@ def handle_template_creation(workspace, uploaded_pipeline_version, yes):
             )
 
 
-@pipelines.command("push")
-@click.argument(
-    "path",
-    type=click.Path(
-        exists=True,
-        path_type=Path,
-        file_okay=False,
-        dir_okay=True,
-    ),
-)
-@click.option(
-    "--name",
-    "-n",
-    default=None,
-    type=str,
-    help="Name of the version",
-    prompt="Name of the version",
-    prompt_required=False,
-)
-@click.option(
-    "--description",
-    "-d",
-    default=None,
-    type=str,
-    help="Description of the version",
-    prompt="Description of the version",
-    prompt_required=False,
-)
-@click.option(
-    "--link",
-    "-l",
-    type=str,
-    callback=validate_url,
-    help="Link to the version commit",
-    prompt="Link of the version release",
-    prompt_required=False,
-)
 @pipelines.command("push")
 @click.argument(
     "path",

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -247,7 +247,7 @@ def propose_to_create_template_version(workspace, pipeline_version, yes):
             template = create_pipeline_template_version(workspace, pipeline["id"], pipeline_version["id"], changelog)
             click.echo(
                 click.style(
-                    f"✅ New version '{template['currentVersion']['versionNumber']}' of the template '{template['name']}' created! You can view the new template version in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/templates/{urllib.parse.quote(template['code'])}/versions', fg='bright_blue', underline=True)}",
+                    f"✅ New version '{template['currentVersion']['versionNumber']}' of the template '{template['name']}' created! You can view the new template version in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/templates/{urllib.parse.quote(template["code"])}/versions', fg='bright_blue', underline=True)}",
                     fg="green",
                 )
             )

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -349,13 +349,12 @@ def pipelines_push(
             click.echo("Please provide an optional changelog for the new version of the template:")
             changelog = click.prompt("Changelog", type=str)
             try:
-                # TODO : link
-                create_pipeline_template_version(
+                template = create_pipeline_template_version(
                     workspace, uploaded_pipeline["id"], uploaded_pipeline_version["id"], changelog
                 )
                 click.echo(
                     click.style(
-                        f"✅ New version of the template '{uploaded_pipeline['template']['name']}' created!",
+                        f"✅ New version '{template['currentVersion']['versionNumber']}' of the template '{template['name']}' created! You can view the new template version in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/templates/{template.code}/versions', fg='bright_blue', underline=True)}",
                         fg="green",
                     )
                 )

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -2,6 +2,7 @@
 
 import json
 import signal
+import urllib
 from datetime import datetime
 from importlib.metadata import version
 from pathlib import Path
@@ -246,7 +247,7 @@ def propose_to_create_template_version(workspace, pipeline_version, yes):
             template = create_pipeline_template_version(workspace, pipeline["id"], pipeline_version["id"], changelog)
             click.echo(
                 click.style(
-                    f"✅ New version '{template['currentVersion']['versionNumber']}' of the template '{template['name']}' created! You can view the new template version in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/templates/{template['code']}/versions', fg='bright_blue', underline=True)}",
+                    f"✅ New version '{template['currentVersion']['versionNumber']}' of the template '{template['name']}' created! You can view the new template version in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/templates/{urllib.parse.quote(template['code'])}/versions', fg='bright_blue', underline=True)}",
                     fg="green",
                 )
             )

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -225,13 +225,13 @@ def pipelines_init(name: str):
         )
 
 
-def handle_template_creation(workspace, uploaded_pipeline_version, yes):
-    """Handle the creation of a new template version based on the uploaded pipeline."""
-    uploaded_pipeline = uploaded_pipeline_version["pipeline"]
-    if uploaded_pipeline["template"] and uploaded_pipeline["permissions"]["createTemplateVersion"]:
+def propose_to_create_template_version(workspace, pipeline_version, yes):
+    """Propose to create a new version of the template if the pipeline is based on a template."""
+    pipeline = pipeline_version["pipeline"]
+    if pipeline["template"] and pipeline["permissions"]["createTemplateVersion"]:
         if not yes:
             click.confirm(
-                f"The template {click.style(uploaded_pipeline['template']['name'], bold=True)} is based on this pipeline, do you want to publish a new version of the template as well?",
+                f"The template {click.style(pipeline['template']['name'], bold=True)} is based on this pipeline, do you want to publish a new version of the template as well?",
                 True,
                 abort=True,
             )
@@ -243,9 +243,7 @@ def handle_template_creation(workspace, uploaded_pipeline_version, yes):
             )
         )
         try:
-            template = create_pipeline_template_version(
-                workspace, uploaded_pipeline["id"], uploaded_pipeline_version["id"], changelog
-            )
+            template = create_pipeline_template_version(workspace, pipeline["id"], pipeline_version["id"], changelog)
             click.echo(
                 click.style(
                     f"✅ New version '{template['currentVersion']['versionNumber']}' of the template '{template['name']}' created! You can view the new template version in OpenHEXA on {click.style(f'{settings.public_api_url}/workspaces/{workspace}/templates/{template['code']}/versions', fg='bright_blue', underline=True)}",
@@ -374,7 +372,7 @@ def pipelines_push(
                 err=True,
                 exception=e,
             )
-        handle_template_creation(workspace, uploaded_pipeline_version, yes)
+        propose_to_create_template_version(workspace, uploaded_pipeline_version, yes)
 
 
 @pipelines.command("download")

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -240,7 +240,7 @@ def propose_to_create_template_version(workspace, pipeline_version, yes):
             ""
             if yes
             else click.prompt(
-                f"{click.style("Changelog", bold=True)} (optional)", type=str, default="", show_default=False
+                f"{click.style('Changelog', bold=True)} (optional)", type=str, default="", show_default=False
             )
         )
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -127,15 +127,22 @@ class CliRunTest(TestCase):
             mock_pipeline = MagicMock(spec=Pipeline)
             mock_pipeline.code = pipeline_name
             mock_get_pipeline.return_value = mock_pipeline
+            template = {
+                "id": "template_id",
+                "name": "test_template",
+                "code": "template_code",
+                "currentVersion": {"versionNumber": "1.0"},
+            }
             mock_upload_pipeline.return_value = {
                 "versionName": version,
                 "pipeline": {
                     "id": "pipeline_id",
                     "permissions": {"createTemplateVersion": True},
-                    "template": {"id": "template_id", "name": "test_template"},
+                    "template": template,
                 },
                 "id": "pipeline_version_id",
             }
+            mock_create_template.return_value = template
 
             result = self.runner.invoke(pipelines_push, [tmp, "--name", version])
             self.assertEqual(result.exit_code, 0)
@@ -148,6 +155,13 @@ class CliRunTest(TestCase):
             )
             self.assertTrue(mock_upload_pipeline.called)
             mock_create_template.assert_called_with("workspace", "pipeline_id", "pipeline_version_id", "")
+            self.assertIn(
+                (
+                    "✅ New version '1.0' of the template 'test_template' created! "
+                    "You can view the new template version in OpenHEXA on https://www.bluesquarehub.com/workspaces/workspace/templates/template_code/versions"
+                ),
+                result.output,
+            )
 
     @patch("openhexa.cli.api.graphql")
     def test_workspaces_add_not_found(self, mock_graphql):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,15 +126,13 @@ class CliRunTest(TestCase):
             mock_graphql.return_value = setup_graphql_response()
             mock_pipeline = MagicMock(spec=Pipeline)
             mock_pipeline.code = pipeline_name
-            mock_pipeline.template = {"name": "test_template"}
-            mock_pipeline.permissions = {"createTemplateVersion": True}
             mock_get_pipeline.return_value = mock_pipeline
             mock_upload_pipeline.return_value = {
                 "versionName": version,
                 "pipeline": {
-                    "template": {"name": "test_template"},
-                    "permissions": {"createTemplateVersion": True},
                     "id": "pipeline_id",
+                    "permissions": {"createTemplateVersion": True},
+                    "template": {"id": "template_id", "name": "test_template"},
                 },
                 "id": "pipeline_version_id",
             }
@@ -149,9 +147,7 @@ class CliRunTest(TestCase):
                 result.output,
             )
             self.assertTrue(mock_upload_pipeline.called)
-            mock_create_template.assert_called_with(
-                "workspace", mock_pipeline.id, mock_upload_pipeline.return_value["id"], ""
-            )
+            mock_create_template.assert_called_with("workspace", "pipeline_id", "pipeline_version_id", "")
 
     @patch("openhexa.cli.api.graphql")
     def test_workspaces_add_not_found(self, mock_graphql):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,7 +163,7 @@ class CliRunTest(TestCase):
             self.assertIn(
                 (
                     f"✅ New version '{template['currentVersion']['versionNumber']}' of the template '{template['name']}' created! "
-                    f"You can view the new template version in OpenHEXA on https://www.bluesquarehub.com/workspaces/workspace/templates/{template["code"]}/versions"
+                    f"You can view the new template version in OpenHEXA on https://www.bluesquarehub.com/workspaces/workspace/templates/{template['code']}/versions"
                 ),
                 result.output,
             )


### PR DESCRIPTION
Ask if a template version needs to be created when pushing a new pipeline version

## Changes

- Import graphQL query to create the template version
- `propose_to_create_template_version` helper to automate the template version creation
- Extended existing unit test to verify that the template version creation is happening

## How/what to test

When pushing a new pipeline version it should be possible to create a template version as well