### PR TITLE
fix: getting permissions of create template version (HEXA-1228)

### DIFF
--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -570,7 +570,9 @@ def upload_pipeline(
                         pipeline {
                             id
                             permissions {
-                                createTemplateVersion
+                                createTemplateVersion {
+                                    isAllowed
+                                }
                             }
                             template {
                                 id

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -230,7 +230,7 @@ def pipelines_init(name: str):
 def propose_to_create_template_version(workspace, pipeline_version, yes):
     """Propose to create a new version of the template if the pipeline is based on a template."""
     pipeline = pipeline_version["pipeline"]
-    if pipeline["template"] and pipeline["permissions"]["createTemplateVersion"]:
+    if pipeline["template"] and pipeline["permissions"]["createTemplateVersion"]["isAllowed"]:
         if not yes and not click.confirm(
             f"The template {click.style(pipeline['template']['name'], bold=True)} is based on this pipeline, do you want to publish a new version of the template as well?",
             True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,7 +153,7 @@ class CliRunTest(TestCase):
                 "versionName": version,
                 "pipeline": {
                     "id": pipeline_id,
-                    "permissions": {"createTemplateVersion": True},
+                    "permissions": {"createTemplateVersion": {"isAllowed": True}},
                     "template": template,
                 },
                 "id": pipeline_version_id,
@@ -269,7 +269,7 @@ class CliRunTest(TestCase):
                 "versionName": version,
                 "pipeline": {
                     "id": pipeline_id,
-                    "permissions": {"createTemplateVersion": True},
+                    "permissions": {"createTemplateVersion": {"isAllowed": True}},
                     "template": template,
                 },
                 "id": pipeline_version_id,


### PR DESCRIPTION
The permission type of create template version has been changed from boolean to more complex structure with reasons for permission denial.

## Changes

- Fix the parsing of the permission