### PR TITLE
fix: set default url to prod env

### DIFF
--- a/openhexa/cli/settings.py
+++ b/openhexa/cli/settings.py
@@ -23,7 +23,7 @@ def _open_config():
         config.read_string(
             """
         [openhexa]
-        url=https://api.openhexa.org
+        url=https://app.openhexa.org
 
         [workspaces]
         """


### PR DESCRIPTION
sets default url to prod one