### PR TITLE
fix: type of arg `type` should be of type `type`

### DIFF
--- a/openhexa/sdk/pipelines/parameter.py
+++ b/openhexa/sdk/pipelines/parameter.py
@@ -387,16 +387,7 @@ class Parameter:
         self,
         code: str,
         *,
-        type: str
-        | int
-        | bool
-        | S3Connection
-        | CustomConnection
-        | DHIS2Connection
-        | IASOConnection
-        | PostgreSQLConnection
-        | GCSConnection
-        | Dataset,
+        type: type,
         name: str | None = None,
         choices: typing.Sequence | None = None,
         help: str | None = None,
@@ -562,17 +553,7 @@ def validate_parameters(parameters: list[Parameter]):
 def parameter(
     code: str,
     *,
-    type: str
-    | int
-    | bool
-    | float
-    | DHIS2Connection
-    | IASOConnection
-    | PostgreSQLConnection
-    | GCSConnection
-    | S3Connection
-    | CustomConnection
-    | Dataset,
+    type: type,
     name: str | None = None,
     choices: typing.Sequence | None = None,
     help: str | None = None,

--- a/openhexa/sdk/pipelines/parameter.py
+++ b/openhexa/sdk/pipelines/parameter.py
@@ -387,7 +387,19 @@ class Parameter:
         self,
         code: str,
         *,
-        type: type,
+        type: type[
+            str
+            | int
+            | bool
+            | float
+            | DHIS2Connection
+            | IASOConnection
+            | PostgreSQLConnection
+            | GCSConnection
+            | S3Connection
+            | CustomConnection
+            | Dataset
+        ],
         name: str | None = None,
         choices: typing.Sequence | None = None,
         help: str | None = None,
@@ -553,7 +565,19 @@ def validate_parameters(parameters: list[Parameter]):
 def parameter(
     code: str,
     *,
-    type: type,
+    type: type[
+        str
+        | int
+        | bool
+        | float
+        | DHIS2Connection
+        | IASOConnection
+        | PostgreSQLConnection
+        | GCSConnection
+        | S3Connection
+        | CustomConnection
+        | Dataset
+    ],
     name: str | None = None,
     choices: typing.Sequence | None = None,
     help: str | None = None,


### PR DESCRIPTION
When decorating a pipeline with `@parameter`, we use the `type=` argument to specify parameter type:

``` python
@pipeline(...)
@parameter(
    code="src_dhis2",
    type=DHIS2Connection,
    name="Source DHIS2 instance",
)
@parameter(
    code="dst_dataset",
    type=Dataset,
    name="Output dataset",
)
@parameter(
    code="org_units",
    type=str,
    multiple=True,
    name="Organisation units",
)
def my_pipeline():
   ...
```

We are not passing an instance of a class but the class/type itself. Therefore the annotated type of `type` should be of type `type` and not `str | DHIS2Connection | Dataset | ...`.