### PR TITLE
feat: pass env variables to container

### DIFF
--- a/openhexa/sdk/pipelines/utils.py
+++ b/openhexa/sdk/pipelines/utils.py
@@ -172,4 +172,9 @@ def get_local_workspace_config(path: Path):
         if "image" in local_workspace_config:
             env_vars["WORKSPACE_DOCKER_IMAGE"] = local_workspace_config["image"]
 
+        # Additional environment variables
+        if "env" in local_workspace_config:
+            for key, value in local_workspace_config["env"].items():
+                env_vars[key] = str(value)
+
     return env_vars


### PR DESCRIPTION
Add a way to pass env variables to containers through `workspace.yaml`.

## Changes

Parse `env` section in `workspace.yaml` and add the env variables to the local workspace config.

Might be better to pass env variables through an argument of `openhexa pipelines run` instead? Or fetch these values automatically in the SDK instead of requiring the user to write down these env variables?

This allows to do things such as:
* Using connections from remote workspace in local runs
* Reading & writing datasets from remote workspace in local runs
* Reading & writing to workspace database in local runs
* Potentially also do all that in CI/CD pipelines to test pipelines before deployment



## Screenshots / screencast

`workspace.yaml`:

![Screenshot from 2025-06-26 16-03-11](https://github.com/user-attachments/assets/019b51b5-8d55-4567-b303-2bb9a66d8959)

Reading and writing remote datasets:

![image](https://github.com/user-attachments/assets/1b825a91-eb1b-4f53-b473-7baec2007ff0)


