### PR TITLE
fix: add conda build to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,24 @@ jobs:
         
       - name: Run tests
         run: pytest --cov=. --cov-report html --cov-report term --cov-fail-under=25
+  conda-build:
+    name: Conda build check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-activate-base: true
+          activate-environment: true
+          python-version: 3.13
+
+      - name: Install conda tools
+        run: conda install -y conda-build anaconda-client
+
+      - name: Dry-run conda build
+        shell: bash -l {0}
+        working-directory: recipe
+        run: |
+          conda build . --channel conda-forge --channel bioconda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,18 @@ jobs:
       - name: Install conda tools
         run: conda install -y conda-build anaconda-client
 
+      - name: Extract version from pyproject.toml
+        id: extract_version
+        working-directory: .
+        run: |
+          VERSION=$(awk -F\" '/^version =/ { print $2; exit }' pyproject.toml)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Extracted version: $VERSION"
+
       - name: Dry-run conda build
         shell: bash -l {0}
         working-directory: recipe
+        env:
+          VERSION: ${{ env.VERSION }}
         run: |
           conda build . --channel conda-forge --channel bioconda


### PR DESCRIPTION
We have two jobs in parallel :
- ci for every branch commit
- publish on release 

When we publish we do conda build and it fails when we forget to add packages, but as the build status is only displayed from CI flow, we never get notified until docker-images build fails. 
I have added packages build to CI flow so we notified in CI if there is an unmet dependency

Closes: https://bluesquare.atlassian.net/browse/HEXA-1331?atlOrigin=eyJpIjoiYWU4Y2ZiYjI1ZWRlNGQ3Njk0ZDEyMzgzMzAwNjc1YjUiLCJwIjoiaiJ9