### PR TITLE
fix: running pipeline locally with custom image (HEXA-1337)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,17 @@ docker build --platform linux/amd64 -t local_image:v1 -f images/Dockerfile .
 
 Then reference the image name and tag in the `.env` file of your OpenHexa app :
 
-```
+```dotenv
 DEFAULT_WORKSPACE_IMAGE=local_image:v1
 ```
+
+Or you can set the following in your `workspace.yaml` configuration file in your pipeline directory:
+
+```yaml
+env:
+  WORKSPACE_DOCKER_IMAGE: local_image:v1
+```
+
 
 ### Running the tests
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -2,10 +2,10 @@ FROM blsq/openhexa-base-environment:latest
 
 USER root
 
-WORKDIR /app
-COPY . /app
+WORKDIR /home/hexa
+COPY . /home/hexa
 
 RUN pip install build
 RUN python -m build .
 
-RUN pip install --no-cache-dir /app/dist/*.tar.gz && rm -rf /app/dist/*.tar.gz
+RUN pip install --no-cache-dir /home/hexa/dist/*.tar.gz && rm -rf /home/hexa/dist/*.tar.gz


### PR DESCRIPTION
Doing `docker build --platform linux/amd64 -t local_image:v1 -f images/Dockerfile .`
And then using this image locally with `WORKSPACE_DOCKER_IMAGE: local_image:v1` caused 

```
❯ openhexa pipelines run .                                                       09:29:17
Creating pipeline container with image 'local_image:v1'...

Run logs
No pipeline found


❌ Error in pipeline
Aborted!
```

## Changes
 - Updated doc with more precise instructions
 - Fixed the workdir in the Dockerfile and updated related references