### PR TITLE
feat: add HEXA_VERIFY_SSL option to disable ssl certificate

### DIFF
--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -110,22 +110,22 @@ def get_library_versions() -> tuple[str, str]:
         return installed_version, installed_version
 
 
-def _detect_graphql_breaking_changes_if_needed(token):
+def _detect_graphql_breaking_changes_if_needed(token, no_verify=False):
     """Detect breaking changes if not done recently between the schema referenced in the SDK and the server using graphql-core."""
     ONE_HOUR = 60 * 60
     now_timestamp = int(datetime.now().timestamp())
     if not settings.last_breaking_change_check or now_timestamp - settings.last_breaking_change_check > ONE_HOUR:
-        _detect_graphql_breaking_changes(token)
+        _detect_graphql_breaking_changes(token, no_verify=no_verify)
         settings.last_breaking_change_check = now_timestamp
 
 
-def _detect_graphql_breaking_changes(token):
+def _detect_graphql_breaking_changes(token, no_verify=False):
     """Detect breaking changes between the schema referenced in the SDK and the server using graphql-core."""
     stored_schema_obj = build_schema(
         (Path(__file__).parent.parent / "graphql" / "schema.generated.graphql").open().read()
     )
     server_schema_obj = build_client_schema(
-        _query_graphql(get_introspection_query(input_value_deprecation=True), token=token)
+        _query_graphql(get_introspection_query(input_value_deprecation=True), token=token, no_verify=no_verify)
     )
 
     breaking_changes = find_breaking_changes(stored_schema_obj, server_schema_obj)
@@ -145,13 +145,13 @@ def _detect_graphql_breaking_changes(token):
         )
 
 
-def graphql(query: str, variables=None, token=None):
+def graphql(query: str, variables=None, token=None, no_verify=False):
     """Check that there is no breaking change and perform a GraphQL request."""
-    _detect_graphql_breaking_changes_if_needed(token)
-    return _query_graphql(query, variables, token)
+    _detect_graphql_breaking_changes_if_needed(token, no_verify=no_verify)
+    return _query_graphql(query, variables, token, no_verify=no_verify)
 
 
-def _query_graphql(query: str, variables=None, token=None):
+def _query_graphql(query: str, variables=None, token=None, no_verify=False):
     """Perform a GraphQL request."""
     url = settings.api_url + "/graphql/"
     if token is None:
@@ -167,7 +167,7 @@ def _query_graphql(query: str, variables=None, token=None):
         click.echo(f"Query: {query}")
         click.echo(f"Variables: {variables}")
 
-    session = create_requests_session()
+    session = create_requests_session(verify=not no_verify)
 
     response = session.post(
         url,
@@ -201,7 +201,7 @@ def get_skeleton_dir():
     return Path(__file__).parent / "skeleton"
 
 
-def get_workspace(slug: str, token: str):
+def get_workspace(slug: str, token: str, no_verify: bool = False):
     """Get a single workspace."""
     return graphql(
         """
@@ -214,6 +214,7 @@ def get_workspace(slug: str, token: str):
             """,
         {"slug": slug},
         token,
+        no_verify=no_verify,
     )["workspace"]
 
 

--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -30,6 +30,16 @@ from openhexa.sdk.pipelines.runtime import get_pipeline
 from openhexa.utils import create_requests_session, stringcase
 
 
+def handle_ssl_error(e):
+    """Handle SSL certificate verification errors with helpful message."""
+    if "SSL certificate verification failed" in str(e) or "CERTIFICATE_VERIFY_FAILED" in str(e):
+        raise GraphQLError(
+            "SSL certificate verification failed. "
+            "If you want to disable SSL verification, set the environment variable: HEXA_VERIFY_SSL=false"
+        )
+    raise
+
+
 class InvalidDefinitionError(Exception):
     """Raised whenever pipeline parameters and/or pipeline options are incompatible."""
 
@@ -785,7 +795,7 @@ class OpenHexaClient(BaseOpenHexaClient):
             response = super().execute(query=query, **kwargs)
         except Exception as e:
             if "CERTIFICATE_VERIFY_FAILED" in str(e):
-                raise Exception(
+                raise GraphQLError(
                     "SSL certificate verification failed. "
                     "If you want to disable SSL verification, set the environment variable: HEXA_VERIFY_SSL=false"
                 )
@@ -804,7 +814,7 @@ class OpenHexaClient(BaseOpenHexaClient):
             data = super().get_data(response)
         except Exception as e:
             if "CERTIFICATE_VERIFY_FAILED" in str(e):
-                raise Exception(
+                raise GraphQLError(
                     "SSL certificate verification failed. "
                     "If you want to disable SSL verification, set the environment variable: HEXA_VERIFY_SSL=false"
                 )

--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -187,11 +187,10 @@ def _query_graphql(query: str, variables=None, token=None):
             },
             json={"query": query, "variables": variables},
         )
+        response.raise_for_status()
     except requests.exceptions.SSLError as e:
         handle_ssl_error(e)
-        raise GraphQLError(str(e))
-    try:
-        response.raise_for_status()
+        raise
     except requests.exceptions.HTTPError as e:
         raise GraphQLError(str(e))
 

--- a/openhexa/cli/api.py
+++ b/openhexa/cli/api.py
@@ -188,11 +188,7 @@ def _query_graphql(query: str, variables=None, token=None):
             json={"query": query, "variables": variables},
         )
     except requests.exceptions.SSLError as e:
-        if "CERTIFICATE_VERIFY_FAILED" in str(e):
-            raise GraphQLError(
-                "SSL certificate verification failed. "
-                "If you want to disable SSL verification, set the environment variable: HEXA_VERIFY_SSL=false"
-            )
+        handle_ssl_error(e)
         raise GraphQLError(str(e))
     try:
         response.raise_for_status()

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -93,18 +93,13 @@ def workspaces(ctx):
     confirmation_prompt=False,
     envvar="HEXA_TOKEN",
 )
-@click.option(
-    "--no-verify",
-    is_flag=True,
-    help="Disable SSL certificate verification",
-)
-def workspaces_add(slug, token, no_verify):
+def workspaces_add(slug, token):
     """Add a workspace to the configuration and activate it. The access token is required to access the workspace."""
     if slug in settings.workspaces:
         click.echo(f"Workspace {slug} already exists. We will only update its token.")
     else:
         click.echo(f"Adding workspace {slug}")
-    if get_workspace(slug, token, no_verify=no_verify):
+    if get_workspace(slug, token):
         settings.add_workspace(slug, token)
     else:
         _terminate(

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -93,13 +93,18 @@ def workspaces(ctx):
     confirmation_prompt=False,
     envvar="HEXA_TOKEN",
 )
-def workspaces_add(slug, token):
+@click.option(
+    "--no-verify",
+    is_flag=True,
+    help="Disable SSL certificate verification",
+)
+def workspaces_add(slug, token, no_verify):
     """Add a workspace to the configuration and activate it. The access token is required to access the workspace."""
     if slug in settings.workspaces:
         click.echo(f"Workspace {slug} already exists. We will only update its token.")
     else:
         click.echo(f"Adding workspace {slug}")
-    if get_workspace(slug, token):
+    if get_workspace(slug, token, no_verify=no_verify):
         settings.add_workspace(slug, token)
     else:
         _terminate(

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -170,6 +170,7 @@ def config(ctx):
     if ctx.invoked_subcommand is None:
         click.echo("Debug: " + ("True" if settings.debug else "False"))
         click.echo(f"Backend URL: {settings.api_url}")
+        click.echo("SSL Verification: " + ("True" if settings.verify_ssl else "False"))
         click.echo(f"Current workspace: {settings.current_workspace}")
         click.echo("\nWorkspaces:")
         click.echo("\n".join(settings.workspaces.keys()))

--- a/openhexa/cli/cli.py
+++ b/openhexa/cli/cli.py
@@ -617,7 +617,8 @@ def pipelines_list():
     if settings.current_workspace is None:
         _terminate("No workspace activated", err=True)
 
-    workspace_pipelines = OpenHexaClient().pipelines(workspace_slug=settings.current_workspace).items
+    with OpenHexaClient() as client:
+        workspace_pipelines = client.pipelines(workspace_slug=settings.current_workspace).items
     if len(workspace_pipelines) == 0:
         click.echo(f"No pipelines in workspace {settings.current_workspace}")
         return

--- a/openhexa/cli/settings.py
+++ b/openhexa/cli/settings.py
@@ -53,10 +53,7 @@ class Settings:
     @property
     def verify_ssl(self):
         """Return the SSL verification flag from environment variables."""
-        env_value = os.getenv("HEXA_VERIFY_SSL")
-        if env_value is None:
-            return True
-        return env_value.lower() not in ("0", "false")
+        return os.getenv("HEXA_VERIFY_SSL", "True").lower() not in ("0", "false")
 
     @property
     def api_url(self):

--- a/openhexa/cli/settings.py
+++ b/openhexa/cli/settings.py
@@ -56,7 +56,7 @@ class Settings:
         env_value = os.getenv("HEXA_VERIFY_SSL")
         if env_value is None:
             return True
-        return env_value.lower() in ("1", "true", "yes", "on")
+        return env_value.lower() not in ("0", "false")
 
     @property
     def api_url(self):

--- a/openhexa/cli/settings.py
+++ b/openhexa/cli/settings.py
@@ -51,6 +51,14 @@ class Settings:
         return os.getenv("DEBUG") or os.getenv("HEXA_DEBUG")
 
     @property
+    def verify_ssl(self):
+        """Return the SSL verification flag from environment variables."""
+        env_value = os.getenv("HEXA_VERIFY_SSL")
+        if env_value is None:
+            return True
+        return env_value.lower() in ("1", "true", "yes", "on")
+
+    @property
     def api_url(self):
         """Return the API URL from the settings file or environment variables."""
         url_from_env = os.getenv("HEXA_API_URL") or os.getenv("HEXA_SERVER_URL")

--- a/openhexa/graphql/base_openhexa_client.py
+++ b/openhexa/graphql/base_openhexa_client.py
@@ -3,26 +3,32 @@
 import logging
 from importlib.metadata import version
 
+import httpx
+
 from openhexa.graphql.graphql_client import Client
 
 
 class BaseOpenHexaClient(Client):
     """OpenHexaClient is a class that provides methods to interact with the OpenHexa GraphQL API."""
 
-    def __init__(self, url: str, token: str):
+    def __init__(self, url: str, token: str, verify: bool = True):
         """Initialize the OpenHexaClient with the OpenHexa API URL and headers.
 
         Args:
             url: GraphQL API URL.
             token: Authentication token.
+            verify: Whether to verify SSL certificates.
         """
         self.token = token
+        headers = {
+            "User-Agent": f"openhexa-sdk/{version('openhexa.sdk')}",
+            "Authorization": f"Bearer {self.token}",
+        }
+        http_client = httpx.Client(headers=headers, verify=verify)
         super().__init__(
             url=url,
-            headers={
-                "User-Agent": f"openhexa-sdk/{version('openhexa.sdk')}",
-                "Authorization": f"Bearer {self.token}",
-            },
+            headers=headers,
+            http_client=http_client,
         )
         logging.getLogger("httpx").setLevel(
             logging.WARNING

--- a/openhexa/sdk/utils.py
+++ b/openhexa/sdk/utils.py
@@ -64,13 +64,9 @@ class OpenHexaClient(BaseOpenHexaClient):
             server_url: Server URL. If not provided, will use HEXA_SERVER_URL environment variable.
         """
         url = server_url or f"{os.environ['HEXA_SERVER_URL'].rstrip('/')}/graphql/"
-        token = token or os.environ.get("HEXA_TOKEN")
+        token = token or os.getenv("HEXA_TOKEN")
 
-        env_value = os.environ.get("HEXA_VERIFY_SSL")
-        if env_value is None:
-            verify_ssl = True
-        else:
-            verify_ssl = env_value.lower() not in ("0", "false")
+        verify_ssl = os.getenv("HEXA_VERIFY_SSL", "True").lower() not in ("0", "false")
 
         super().__init__(url=url, token=token, verify=verify_ssl)
 

--- a/openhexa/sdk/utils.py
+++ b/openhexa/sdk/utils.py
@@ -66,7 +66,13 @@ class OpenHexaClient(BaseOpenHexaClient):
         url = server_url or f"{os.environ['HEXA_SERVER_URL'].rstrip('/')}/graphql/"
         token = token or os.environ.get("HEXA_TOKEN")
 
-        super().__init__(url=url, token=token)
+        env_value = os.environ.get("HEXA_VERIFY_SSL")
+        if env_value is None:
+            verify_ssl = True
+        else:
+            verify_ssl = env_value.lower() not in ("0", "false")
+
+        super().__init__(url=url, token=token, verify=verify_ssl)
 
 
 class Iterator(metaclass=abc.ABCMeta):

--- a/openhexa/utils/session.py
+++ b/openhexa/utils/session.py
@@ -10,9 +10,11 @@ def create_requests_session(
     retries=3,
     backoff_factor=0.3,
     status_forcelist=(500, 502, 504),
+    verify=True,
 ) -> Session:
     """Return a Session object with retry capability."""
     session = requests.Session()
+    session.verify = verify
     retry = Retry(
         total=retries,
         read=retries,

--- a/openhexa/utils/session.py
+++ b/openhexa/utils/session.py
@@ -1,5 +1,6 @@
 """Custom HttpClient with retry mechanism."""
 
+
 import requests
 from requests import Session
 from requests.adapters import HTTPAdapter

--- a/openhexa/utils/session.py
+++ b/openhexa/utils/session.py
@@ -2,6 +2,7 @@
 
 
 import requests
+import urllib3
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
@@ -16,6 +17,10 @@ def create_requests_session(
     """Return a Session object with retry capability."""
     session = requests.Session()
     session.verify = verify
+
+    if not verify:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
     retry = Retry(
         total=retries,
         read=retries,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,4 +42,5 @@ def settings(monkeypatch):
     settings_mock.debug = False
     settings_mock.access_token = "token"
     settings_mock.log_level = LogLevel.INFO
+    settings_mock.verify_ssl = True
     return settings_mock

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,15 @@ from zipfile import ZipFile
 import pytest
 from click.testing import CliRunner
 
-from openhexa.cli.cli import pipelines_download, pipelines_push, pipelines_run, select_pipeline, workspaces_add
+from openhexa.cli.api import GraphQLError
+from openhexa.cli.cli import (
+    pipelines_download,
+    pipelines_list,
+    pipelines_push,
+    pipelines_run,
+    select_pipeline,
+    workspaces_add,
+)
 from openhexa.sdk.pipelines import Pipeline
 
 python_file_name = "pipeline.py"
@@ -352,3 +360,18 @@ class CliRunTest(TestCase):
             mock_graphql.return_value = {"workspace": {"name": "test_workspace", "slug": "test_workspace_0000"}}
             result = self.runner.invoke(workspaces_add, ["test_workspace"], input="random_token \n")
             self.assertEqual(result.exit_code, 0)
+
+    @patch.dict(os.environ, {"HEXA_WORKSPACE": "test_workspace"})
+    @patch("openhexa.cli.cli.OpenHexaClient")
+    def test_pipelines_list_ssl_error(self, mock_client_class):
+        """Test the pipelines list command handles SSL errors gracefully."""
+        mock_client = mock_client_class.return_value
+        ssl_error = GraphQLError(
+            "SSL certificate verification failed. If you want to disable SSL verification, set the environment variable: HEXA_VERIFY_SSL=false"
+        )
+        mock_client.pipelines.side_effect = ssl_error
+
+        result = self.runner.invoke(pipelines_list)
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("SSL certificate verification failed", result.output)
+        self.assertIn("HEXA_VERIFY_SSL=false", result.output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -366,6 +366,8 @@ class CliRunTest(TestCase):
     def test_pipelines_list_ssl_error(self, mock_client_class):
         """Test the pipelines list command handles SSL errors gracefully."""
         mock_client = mock_client_class.return_value
+        mock_client.__enter__ = lambda self: mock_client
+        mock_client.__exit__ = lambda self, *args: None
         ssl_error = GraphQLError(
             "SSL certificate verification failed. If you want to disable SSL verification, set the environment variable: HEXA_VERIFY_SSL=false"
         )

--- a/tests/test_ssl_errors.py
+++ b/tests/test_ssl_errors.py
@@ -1,0 +1,30 @@
+"""SSL error handling test module."""
+
+
+import requests
+
+from openhexa.utils.session import create_requests_session
+
+
+class TestSSLErrorHandling:
+    """Test SSL error handling functionality."""
+
+    def test_create_requests_session_verify_default(self):
+        """Test create_requests_session with default verify parameter."""
+        session = create_requests_session()
+        assert session.verify is True
+
+    def test_ssl_error_handling_logic(self):
+        """Test that SSL errors are properly converted to GraphQLError."""
+        ssl_error = requests.exceptions.SSLError("CERTIFICATE_VERIFY_FAILED error")
+
+        if "CERTIFICATE_VERIFY_FAILED" in str(ssl_error):
+            expected_msg = (
+                "SSL certificate verification failed. "
+                "If you want to disable SSL verification, set the environment variable: HEXA_VERIFY_SSL=false"
+            )
+            assert "SSL certificate verification failed" in expected_msg
+            assert "HEXA_VERIFY_SSL=false" in expected_msg
+
+        other_ssl_error = requests.exceptions.SSLError("Some other SSL error")
+        assert "Some other SSL error" in str(other_ssl_error)


### PR DESCRIPTION
Closes https://bluesquare.atlassian.net/browse/HEXA-1350

- Adds HEXA_VERIFY_SSL env variable, if disabled (0, false) api requests to OH instance will skip TLS verification
- Disables warnings in case when HEXA_VERIFY_SSL is disabled
- Provide suggestion to disable SSL verification in if SSL verification have failed

how to test:
```bash
cd openhexa-sdk-python
source venv/bin/activate
pip install .
openhexa config set_url=TLS_ENABLED_URL
export HEXA_VERIFY_SSL=true/false
openhexa workspaces add "workspace"
openhexa pipelines list
```
<img width="1356" height="286" alt="Screenshot 2025-09-02 at 14 20 25" src="https://github.com/user-attachments/assets/6fde05c0-83da-4ec2-b88c-37bb65ef8c43" />
