### PR TITLE
Improve user-friendliness of File class

### DIFF
--- a/openhexa/sdk/files/file.py
+++ b/openhexa/sdk/files/file.py
@@ -12,13 +12,11 @@ class File:
 
     def __init__(
         self,
-        key: str,
         name: str,
         path: str,
         size: int,
         type: str,
     ):
-        self.key = key
         self.name = name
         self.path = path
         self.size = size
@@ -26,4 +24,4 @@ class File:
 
     def __repr__(self) -> str:
         """Safe representation of a file instance."""
-        return f"<File key={self.key} name={self.name} path={self.path}>"
+        return f"<File name={self.name} path={self.path}>"

--- a/openhexa/sdk/workspaces/current_workspace.py
+++ b/openhexa/sdk/workspaces/current_workspace.py
@@ -634,4 +634,11 @@ class CurrentWorkspace:
         ValueError
             If the file does not exist
         """
-        return OpenHexaClient().get_file_by_path(path=path, workspace_slug=self.slug)
+        result = OpenHexaClient().get_file_by_path(path=path, workspace_slug=self.slug)
+
+        return File(
+            name=result.name,
+            path=f"{self.files_path}/{result.key}",
+            size=result.size,
+            type=result.type,
+        )

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -217,7 +217,7 @@ def test_validate_dataset_parameter(mock_get_dataset):
 @mock.patch("openhexa.sdk.workspace.get_file")
 def test_validate_file_parameter(mock_get_file):
     """Check File parameter validation."""
-    file = File(key="test.csv", name="test.csv", path="my_folder/test.csv", size=1024, type="file")
+    file = File(name="test.csv", path="my_folder/test.csv", size=1024, type="file")
     mock_get_file.return_value = file
 
     file_type = FileType()


### PR DESCRIPTION
We want users to be able to directly use `file.path`. `key` is a technical concept that's not very useful for the end user.

Example: `df = pd.read_csv(input_file.path)`.