### PR TITLE
fix: Conditional params safeguard (HEXA-1687)

### DIFF
--- a/openhexa/sdk/pipelines/parameter/decorator.py
+++ b/openhexa/sdk/pipelines/parameter/decorator.py
@@ -129,11 +129,15 @@ class Parameter:
             "required": self.required,
             "multiple": self.multiple,
             "directory": self.directory,
-            "disables": self.disables,
-            "disableWhen": self.disable_when,
         }
         if isinstance(self.choices, ChoicesFromFile):
             d["choicesFromFile"] = self.choices.to_dict()
+        # Only emit the conditional-parameters fields when the feature is actually used: the
+        # backend ``ParameterInput`` type does not define them, and GraphQL rejects the whole
+        # mutation on any unknown input field (see HEXA-1687).
+        if self.disables:
+            d["disables"] = self.disables
+            d["disableWhen"] = self.disable_when
         return d
 
     def _validate_single(self, value: typing.Any):

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -154,8 +154,6 @@ class AstTest(TestCase):
                             "help": "Param help",
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         }
                     ],
                     "timeout": None,
@@ -185,7 +183,7 @@ class AstTest(TestCase):
             params = {p["code"]: p for p in pipeline.to_dict()["parameters"]}
             self.assertEqual(params["run_report_only"]["disables"], ["data_input"])
             self.assertEqual(params["run_report_only"]["disableWhen"], True)
-            self.assertIsNone(params["data_input"]["disables"])
+            self.assertNotIn("disables", params["data_input"])
 
     def test_pipeline_with_disable_when_false(self):
         """The @parameter decorator's 'disable_when' is parsed from the pipeline code."""
@@ -247,8 +245,6 @@ class AstTest(TestCase):
                             "help": "Param help",
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         }
                     ],
                     "timeout": None,
@@ -294,8 +290,6 @@ class AstTest(TestCase):
                             "help": "Dataset",
                             "required": False,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         }
                     ],
                     "timeout": None,
@@ -340,8 +334,6 @@ class AstTest(TestCase):
                             "help": "Param help",
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         }
                     ],
                     "timeout": None,
@@ -414,8 +406,6 @@ class AstTest(TestCase):
                             "help": "Param help",
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         }
                     ],
                     "timeout": None,
@@ -461,8 +451,6 @@ class AstTest(TestCase):
                             "help": "Param help",
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         },
                         {
                             "choices": ["a", "b"],
@@ -476,8 +464,6 @@ class AstTest(TestCase):
                             "help": "Param help 2",
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         },
                     ],
                     "timeout": None,
@@ -545,8 +531,6 @@ class AstTest(TestCase):
                             "help": None,
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         },
                         {
                             "code": "data_element_ids",
@@ -560,8 +544,6 @@ class AstTest(TestCase):
                             "help": None,
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         },
                     ],
                     "timeout": None,
@@ -611,8 +593,6 @@ class AstTest(TestCase):
                             "help": None,
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         },
                         {
                             "code": "org_units",
@@ -626,8 +606,6 @@ class AstTest(TestCase):
                             "help": None,
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         },
                         {
                             "code": "projects",
@@ -641,8 +619,6 @@ class AstTest(TestCase):
                             "help": None,
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         },
                         {
                             "code": "forms",
@@ -656,8 +632,6 @@ class AstTest(TestCase):
                             "help": None,
                             "required": True,
                             "directory": None,
-                            "disables": None,
-                            "disableWhen": True,
                         },
                     ],
                     "timeout": None,

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -18,6 +18,7 @@ from openhexa.sdk import (
 )
 from openhexa.sdk.pipelines.parameter import (
     Boolean,
+    ChoicesFromFile,
     CustomConnectionType,
     DatasetType,
     DHIS2ConnectionType,
@@ -426,15 +427,74 @@ def test_parameter_decorator():
 
 
 def test_parameter_disables_serialization():
-    """The 'disables' option is normalized to a list and serialized in to_dict."""
+    """The 'disables'/'disableWhen' keys are only serialized for controller parameters.
+
+    The backend ``ParameterInput`` GraphQL type does not define these fields, so emitting
+    them for every parameter breaks ``uploadPipeline``. They must be omitted entirely unless
+    the parameter actually uses the conditional-parameters feature.
+    """
     no_disables = Parameter("plain", type=str)
     assert no_disables.disables is None
-    assert no_disables.to_dict()["disables"] is None
+    assert "disables" not in no_disables.to_dict()
+    assert "disableWhen" not in no_disables.to_dict()
 
     controller = Parameter("run_report_only", type=bool, disables=["data_input", "year"])
     assert controller.disables == ["data_input", "year"]
     assert controller.to_dict()["disables"] == ["data_input", "year"]
     assert controller.to_dict()["disableWhen"] is True
+
+
+def _parameter_input_fields() -> set[str]:
+    """Field names defined by the backend ``ParameterInput`` GraphQL input type.
+
+    Parsed from the schema bundled in the SDK (kept in sync with the server by
+    ``ariadne-codegen``), which is exactly the contract ``uploadPipeline`` validates against.
+    """
+    from graphql import build_schema
+
+    from openhexa.graphql import BUNDLED_SCHEMA_PATH
+
+    schema = build_schema(BUNDLED_SCHEMA_PATH.read_text(), assume_valid_sdl=True)
+    return set(schema.type_map["ParameterInput"].fields.keys())
+
+
+def test_to_dict_baseline_keys_are_valid_parameter_input_fields():
+    """Guard against future ``to_dict()`` regressions.
+
+    Every key emitted by a plain ``Parameter.to_dict()`` must be a field defined by the backend
+    ``ParameterInput`` type. GraphQL rejects the entire ``uploadPipeline`` mutation on any unknown
+    input field, so an *unconditional* new key the schema does not define breaks every pipeline
+    push — exactly the HEXA-1687 regression this test exists to prevent. Adding a new always-on
+    field here must go hand in hand with the backend schema change that defines it.
+    """
+    emitted = set(Parameter("plain", type=str).to_dict())
+    unknown = emitted - _parameter_input_fields()
+    assert not unknown, f"to_dict() emits keys not defined by ParameterInput: {sorted(unknown)}"
+
+
+def test_to_dict_choices_from_file_key_is_valid_parameter_input_field():
+    """The conditionally-emitted ``choicesFromFile`` key must also exist in ``ParameterInput``."""
+    emitted = set(Parameter("district", type=str, choices=ChoicesFromFile("districts.csv")).to_dict())
+    unknown = emitted - _parameter_input_fields()
+    assert not unknown, f"to_dict() emits keys not defined by ParameterInput: {sorted(unknown)}"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Backend ParameterInput does not yet define 'disables'/'disableWhen' (HEXA-1687 "
+    "backend pending). Pipelines using conditional parameters cannot be pushed until the server "
+    "schema is regenerated. Remove this marker once it is — strict xfail will flag the XPASS.",
+)
+def test_to_dict_controller_keys_are_valid_parameter_input_fields():
+    """Document that conditional-parameter controllers are not yet pushable.
+
+    A controller emits ``disables``/``disableWhen``, which the current backend ``ParameterInput``
+    rejects. When the server schema gains these fields (and the bundled schema is regenerated),
+    this xfail flips to an unexpected pass and the strict marker fails the suite, prompting removal.
+    """
+    emitted = set(Parameter("controller", type=bool, disables=["plain"]).to_dict())
+    unknown = emitted - _parameter_input_fields()
+    assert not unknown, f"to_dict() emits keys not defined by ParameterInput: {sorted(unknown)}"
 
 
 def test_parameter_disables_dedup_preserves_order():


### PR DESCRIPTION
Fixing bug in https://github.com/BLSQ/snt_development/actions/runs/27815160427/job/82314423275

```
❌ Error while importing pipeline: "[{'message': "Variable '$input' got invalid value 
{'code': 'dhis2_connection', 'type': 'dhis2', 'name': 'DHIS2 connection', 'choices': None, 
'help': 'DHIS2 connection ID', ..., 'multiple': False, 'directory': None, 'disables': None, 
'disableWhen': True} at 'input.parameters[0]'; Field 'disables' is not defined by type 
'ParameterInput'.", 'locations': [{'line': 2, 'column': 37}]}, {'message': "Variable '$input' 
got invalid value {'code': 'dhis2_connection', 'type': 'dhis2', 'name': 'DHIS2 connection', 
'choices': None, 'help': 'DHIS2 connection ID', ..., 'multiple': False, 'directory': None, 
'disables': None, 'disableWhen': True} at 'input.parameters[0]'; Field 'disableWhen' is 
not defined by type 'ParameterInput'."
```

## Changes

The root cause was a payload field the server's ParameterInput doesn't define. 
- This safeguard will add only the new values (disables and disableWhen) when they actually exist, thus avoiding having issues with unupdated openhexa instances.
- Added tests to ensure this doesn't happen in the future
